### PR TITLE
Speed up the inner loop (& grab bag)

### DIFF
--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -280,8 +280,8 @@ int8_t Adafruit_Floppy::track(void) { return _track; }
     @return Number of pulses we actually captured
 */
 /**************************************************************************/
-__attribute__((optimize("O3"))) uint32_t
-Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses) {
+uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses)
+    __attribute__((optimize("O3"))) {
   unsigned pulse_count;
   uint8_t *pulses_ptr = pulses;
   uint8_t *pulses_end = pulses + max_pulses;

--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -280,8 +280,7 @@ int8_t Adafruit_Floppy::track(void) { return _track; }
     @return Number of pulses we actually captured
 */
 /**************************************************************************/
-uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses)
-    __attribute__((optimize("O3"))) {
+uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses) {
   unsigned pulse_count;
   uint8_t *pulses_ptr = pulses;
   uint8_t *pulses_end = pulses + max_pulses;

--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -331,7 +331,11 @@ uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses)
     last_index_state = index_state;
 
     // muahaha, now we can read track data!
-    pulse_count = 0;
+    // Don't start counting at zero because we lost some time checking for
+    // index. Empirically, at 180MHz and -O3 on M4, this gives the most 'even'
+    // timings, moving the bins from 41/63/83 to 44/66/89
+    pulse_count = 3;
+
     // while pulse is in the low pulse, count up
     while (!read_data()) {
       pulse_count++;

--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -1,5 +1,7 @@
 #include "Adafruit_Floppy.h"
 
+#define DEBUG_FLOPPY (0)
+
 // We need to read and write some pins at optimized speeds - use raw registers
 // or native SDK API!
 #ifdef BUSIO_USE_FAST_PINIO
@@ -12,6 +14,13 @@
 #define read_data() gpio_get(_rddatapin)
 #define set_debug_led() gpio_put(led_pin, 1)
 #define clr_debug_led() gpio_put(led_pin, 0)
+#endif
+
+#if !DEBUG_FLOPPY
+#undef set_debug_led
+#undef clr_debug_led
+#define set_debug_led() ((void)0)
+#define clr_debug_led() ((void)0)
 #endif
 
 /**************************************************************************/

--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -280,6 +280,7 @@ int8_t Adafruit_Floppy::track(void) { return _track; }
     @return Number of pulses we actually captured
 */
 /**************************************************************************/
+__attribute__((optimize("O3")))
 uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses) {
   uint16_t pulse_count;
   uint8_t *pulses_ptr = pulses;

--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -282,7 +282,7 @@ int8_t Adafruit_Floppy::track(void) { return _track; }
 /**************************************************************************/
 __attribute__((optimize("O3")))
 uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses) {
-  uint16_t pulse_count;
+  unsigned pulse_count;
   uint8_t *pulses_ptr = pulses;
   uint8_t *pulses_end = pulses + max_pulses;
 

--- a/Adafruit_Floppy.cpp
+++ b/Adafruit_Floppy.cpp
@@ -280,8 +280,8 @@ int8_t Adafruit_Floppy::track(void) { return _track; }
     @return Number of pulses we actually captured
 */
 /**************************************************************************/
-__attribute__((optimize("O3")))
-uint32_t Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses) {
+__attribute__((optimize("O3"))) uint32_t
+Adafruit_Floppy::capture_track(uint8_t *pulses, uint32_t max_pulses) {
   unsigned pulse_count;
   uint8_t *pulses_ptr = pulses;
   uint8_t *pulses_end = pulses + max_pulses;

--- a/Adafruit_Floppy.h
+++ b/Adafruit_Floppy.h
@@ -36,7 +36,8 @@ public:
   int8_t track(void);
   void step(bool dir, uint8_t times);
 
-  uint32_t capture_track(uint8_t *pulses, uint32_t max_pulses);
+  uint32_t capture_track(uint8_t *pulses, uint32_t max_pulses)
+      __attribute__((optimize("O3")));
   void print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
                         uint8_t max_bins = 64);
   void print_pulses(uint8_t *pulses, uint32_t num_pulses);

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -95,6 +95,7 @@ uint8_t cmd_buff_idx = 0;
 #define GW_CMD_RESET     16
 #define GW_CMD_SOURCEBYTES 18
 #define GW_CMD_SINKBYTES 19
+#define GW_CMD_GETPIN 20
 
 #define GW_ACK_OK (byte)0
 #define GW_ACK_BADCMD 1
@@ -443,9 +444,22 @@ void loop() {
      Serial1.print(" ms, ");
      Serial1.print(bytes_per_sec);
      Serial1.println(" bytes per sec");
-  }
+  } else if (cmd == GW_CMD_GETPIN) {
+     uint32_t pin = cmd_buffer[2];
+     reply_buffer[i++] = GW_ACK_OK;
+     Serial1.printf("getpin %d\n\r", pin);
+
+     switch(pin) {
+      case 26:
+        reply_buffer[i++] = digitalRead(TRK0_PIN);
+      break;
+
+      default:
+        reply_buffer[i++] = 0;
+      }
+      Serial.write(reply_buffer, i);
   /********** unknown ! ********/
-   else {
+  } else {
     reply_buffer[i++] = GW_ACK_BADCMD;
     Serial.write(reply_buffer, 2);
   }

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -17,7 +17,7 @@
 #if F_CPU != 180000000L
   #warning "please set CPU speed to 180MHz overclock"
 #endif
-  #define GW_SAMPLEFREQ  20000000UL // 20mhz for samd51
+  #define GW_SAMPLEFREQ  (F_CPU * 11/90) // samd51 is sample rate of 22MHz at 180MHz OC
 #elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
   #define DENSITY_PIN  7     // IDC 2
   #define INDEX_PIN    8     // IDC 8


### PR DESCRIPTION
This series of changes speeds up the inner loop, ~~and also errors when greaseweazel is not compiled with overclocking on the M4 (SAMD51)~~. (doing that broke CI, because it doesn't turn on the overclock setting)

It's tested with the adafruit "debugging" branch of gw and still reads the two test floppies I've been using.  It is a bit surprising to me that no change in GW_SAMPLEFREQ was needed (since at least 2 instructions were knocked out of the inner loop), but there ya go..

By accounting for the time needed to check for the index pulse, the timing is made more even and GW works even without overclocking.

Minimal support for GW_CMD_GETPIN was added, so that the tip of their main branch works with this firmware.