### PR TITLE
Switch rp2040 to streaming flux capture

### DIFF
--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -3,6 +3,7 @@
 
 #include "Arduino.h"
 #include <Adafruit_SPIDevice.h>
+#include <functional>
 // to implement SdFat Block Driver
 #include "SdFat.h"
 #include "SdFatConfig.h"
@@ -53,6 +54,12 @@ public:
 
   uint32_t read_track_mfm(uint8_t *sectors, size_t n_sectors,
                           uint8_t *sector_validity, bool high_density = true);
+  bool stream_track(uint8_t *buf, size_t size, uint32_t revs,
+                    uint32_t capture_ticks, bool store_greaseweazle,
+                    void (*callback)(void *, uint8_t *, size_t), void *arg);
+  bool stream_track(uint8_t *buf, size_t size, uint32_t revs,
+                    uint32_t capture_ticks, bool store_greaseweazle,
+                    const std::function<void(uint8_t *, size_t)> &cb);
   uint32_t capture_track(volatile uint8_t *pulses, uint32_t max_pulses,
                          uint32_t *falling_index_offset,
                          bool store_greaseweazle = false,

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -6,11 +6,17 @@
 #define clr_debug_led() gpio_put(led_pin, 0)
 #define set_write() gpio_put(_wrdatapin, 1)
 #define clr_write() gpio_put(_wrdatapin, 0)
+#include <stddef.h>
 #include <stdint.h>
 extern uint32_t
 rp2040_flux_capture(int indexpin, int rdpin, volatile uint8_t *pulses,
                     volatile uint8_t *end, uint32_t *falling_index_offset,
                     bool store_greaseweazle, uint32_t capture_counts);
+extern bool rp2040_flux_stream(int indexpin, int rdpin, uint8_t *buf,
+                               size_t size, uint32_t revs, uint32_t capture_ms,
+                               bool store_greaseweazle,
+                               void (*callback)(void *, uint8_t *, size_t),
+                               void *arg);
 extern void rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
                               uint8_t *pulses, uint8_t *pulse_end,
                               bool store_greaseweazel);


### PR DESCRIPTION
This improves compatibility with genuine GW hardware, and improves (but doesn't fix; is it a g64conv track numbering bug?) decoding flippy disks with g64conv. It also provided an opportunity to learn how to use the 2nd core on RP2040, bonus for me!

When adding internal debug prints to GW host software, a multi-track capture from genuine GW hardware consists of a partial revolution, followed by several full revolutions. These are sampled without gaps, so software like g64conv which likes to stitch 'index-hole insensitive' formats across the gap can do as it likes; it's advised of (but ignores) the locations where the index was seen:
```
 Total: 232202 samples, 594.17ms
 Revolution 0: 93.06ms
 Revolution 1: 166.87ms
 Revolution 2: 166.87ms
 Revolution 3: 166.87ms 
```

Prior to this change, a capture from Adafruit_Floppy's GW-compatible firmware was shown as
```
 Total: 120485 samples, 652.35ms
 Revolution 0: 0.00ms
 Revolution 1: 162.34ms
 Revolution 2: 55.11ms
 Revolution 3: 162.17ms
 Revolution 4: 55.28ms
 Revolution 5: 162.12ms
```
where there was an always-empty first revolution, then an alternation between a full and a partial revolution. (a 6th, partial revolution may have been discarded internally in GW before this message was printed)

After this, a capture from an RP2040 with the GW-compatible firmware is shown essentially the same as genuine GW.

However, there does seem to be a problem introduced here. With this firmware, GW will sometimes fail to decode any sector but the first, randomly on some tracks of a floppy. The problem moves around but occurs with probability >1/100, so most full disk captures are affected. The resulting sector map looks like:
```
Cyl-> 0         1         2         3         4         5         6         7         
H. S: 01234567890123456789012345678901234567890123456789012345678901234567890123456789
0. 0: ................................................................................
0. 1: ...............X............X...................................................
0. 2: ...............X............X...................................................
0. 3: ...............X............X...................................................
0. 4: ...............X............X...................................................
0. 5: ...............X............X...................................................
0. 6: ...............X............X...................................................
0. 7: ...............X............X...................................................
0. 8: ...............X............X...................................................
0. 9: ...............X............X...................................................
0.10: ...............X............X...................................................
0.11: ...............X............X...................................................
0.12: ...............X............X...................................................
0.13: ...............X............X...................................................
0.14: ...............X............X...................................................
```

Also, continuous capture would need to be implemented for samd51 before this PR should be accepted.