### PR TITLE
Add support for Apple II Floppy drives such as Disk ][

### DIFF
--- a/examples/apple2_test/apple2_test.ino
+++ b/examples/apple2_test/apple2_test.ino
@@ -16,13 +16,14 @@
 #define PHASE4_PIN (11)
 #define RDDATA_PIN (7)  // D5
 #define INDEX_PIN  (A3)
+#define APPLE2_PROTECT_PIN (2) // "SDA"
 #else
 #error "Please set up pin definitions!"
 #endif
 
 Adafruit_Apple2Floppy floppy(INDEX_PIN, ENABLE_PIN,
                              PHASE1_PIN, PHASE2_PIN, PHASE3_PIN, PHASE4_PIN,
-                             -1, -1, -1, RDDATA_PIN);
+                             -1, -1, APPLE2_PROTECT_PIN, RDDATA_PIN);
 
 // WARNING! there are 150K max flux pulses per track!
 uint8_t flux_transitions[MAX_FLUX_PULSE_PER_TRACK];
@@ -68,5 +69,7 @@ void loop() {
   //floppy.print_pulses(flux_transitions, captured_flux);
   floppy.print_pulse_bins(flux_transitions, captured_flux, 255, true);
 
-  yield();
+  Serial.printf("Write protect: %s\n", floppy.get_write_protect() ? "ON" : "off");
+
+  delay(100);
 }

--- a/examples/apple2_test/apple2_test.ino
+++ b/examples/apple2_test/apple2_test.ino
@@ -1,6 +1,14 @@
 #include <Adafruit_Floppy.h>
 
-#if defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
+#define ENABLE_PIN (6)
+#define PHASE1_PIN (A2)
+#define PHASE2_PIN (13)
+#define PHASE3_PIN (12)
+#define PHASE4_PIN (11)
+#define RDDATA_PIN (5)
+#define INDEX_PIN  (A3)
+#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
 #define ENABLE_PIN (8)  // D6
 #define PHASE1_PIN (A2)
 #define PHASE2_PIN (13)

--- a/examples/apple2_test/apple2_test.ino
+++ b/examples/apple2_test/apple2_test.ino
@@ -1,0 +1,64 @@
+#include <Adafruit_Floppy.h>
+
+#if defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define ENABLE_PIN (8)  // D6
+#define PHASE1_PIN (A2)
+#define PHASE2_PIN (13)
+#define PHASE3_PIN (12)
+#define PHASE4_PIN (11)
+#define RDDATA_PIN (7)  // D5
+#define INDEX_PIN  (A3)
+#else
+#error "Please set up pin definitions!"
+#endif
+
+Adafruit_Apple2Floppy floppy(INDEX_PIN, ENABLE_PIN,
+                             PHASE1_PIN, PHASE2_PIN, PHASE3_PIN, PHASE4_PIN,
+                             -1, -1, -1, RDDATA_PIN);
+
+// WARNING! there are 150K max flux pulses per track!
+uint8_t flux_transitions[MAX_FLUX_PULSE_PER_TRACK];
+
+uint32_t time_stamp = 0;
+
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(100);
+
+  Serial.println("its time for a nice floppy transfer!");
+  floppy.debug_serial = &Serial;
+
+  if (!floppy.begin()) {
+    Serial.println("Failed to initialize floppy interface");
+    while (1) yield();
+  }
+
+  floppy.select(true);
+  if (! floppy.spin_motor(true)) {
+    Serial.println("Failed to spin up motor & find index pulse");
+    while (1) yield();
+  }
+
+  Serial.print("Seeking track...");
+  if (! floppy.goto_track(0)) {
+    Serial.println("Failed to seek to track");
+    while (1) yield();
+  }
+  Serial.println("done!");
+
+}
+
+void loop() {
+  uint32_t index_pulse_offset;
+  uint32_t captured_flux = floppy.capture_track(flux_transitions, sizeof(flux_transitions), &index_pulse_offset, true);
+
+  Serial.print("Captured ");
+  Serial.print(captured_flux);
+  Serial.println(" flux transitions");
+
+  //floppy.print_pulses(flux_transitions, captured_flux);
+  floppy.print_pulse_bins(flux_transitions, captured_flux, 255, true);
+
+  yield();
+}

--- a/examples/apple2_test/apple2_test.ino
+++ b/examples/apple2_test/apple2_test.ino
@@ -8,6 +8,7 @@
 #define PHASE4_PIN (11)
 #define RDDATA_PIN (5)
 #define INDEX_PIN  (A3)
+#define APPLE2_PROTECT_PIN (21) // "SDA"
 #elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
 #define ENABLE_PIN (8)  // D6
 #define PHASE1_PIN (A2)
@@ -59,7 +60,7 @@ void setup() {
 }
 
 void loop() {
-  uint32_t index_pulse_offset;
+  int32_t index_pulse_offset;
   uint32_t captured_flux = floppy.capture_track(flux_transitions, sizeof(flux_transitions), &index_pulse_offset, true);
 
   Serial.print("Captured ");

--- a/examples/floppy_capture_track_test/floppy_capture_track_test.ino
+++ b/examples/floppy_capture_track_test/floppy_capture_track_test.ino
@@ -85,7 +85,7 @@ void setup() {
 }
 
 void loop() {
-  uint32_t index_pulse_offset;
+  int32_t index_pulse_offset;
   uint32_t captured_flux = floppy.capture_track(flux_transitions, sizeof(flux_transitions), &index_pulse_offset, true);
 
   Serial.print("Captured ");
@@ -99,7 +99,7 @@ void loop() {
     Serial.print("Ready? ");
     Serial.println(digitalRead(READY_PIN) ? "No" : "Yes");
     Serial.print("Write Protected? ");
-    Serial.println(digitalRead(PROT_PIN) ? "No" : "Yes");
+    Serial.println(floppy.get_write_protect() ? "Yes" : "No");
     Serial.print("Track 0? ");
     Serial.println(digitalRead(TRK0_PIN) ? "No" : "Yes");
     time_stamp = millis();

--- a/examples/floppy_write_test/floppy_write_test.ino
+++ b/examples/floppy_write_test/floppy_write_test.ino
@@ -85,7 +85,7 @@ void setup() {
 }
 
 void loop() {
-  uint32_t index_pulse_offset;
+  int32_t index_pulse_offset;
   uint32_t captured_flux = floppy.capture_track(flux_transitions, sizeof(flux_transitions), &index_pulse_offset, true);
 
   Serial.print("Captured ");

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -30,15 +30,15 @@
 #define READY_PIN     7    // IDC 34
 
 // jepler's prototype board, subject to change
-#define APPLE2_ENABLE_PIN (8)  // D6
-#define APPLE2_PHASE1_PIN (A2)
-#define APPLE2_PHASE2_PIN (13)
-#define APPLE2_PHASE3_PIN (12)
-#define APPLE2_PHASE4_PIN (11)
-#define APPLE2_RDDATA_PIN (7)  // D5
-#define APPLE2_WRDATA_PIN (-1)
-#define APPLE2_WRGATE_PIN (-1)
-#define APPLE2_PROTECT_PIN (-1)
+#define APPLE2_PHASE1_PIN (A2)        // IDC 2
+#define APPLE2_PHASE2_PIN (13)        // IDC 4
+#define APPLE2_PHASE3_PIN (12)        // IDC 6
+#define APPLE2_PHASE4_PIN (11)        // IDC 8
+#define APPLE2_WRGATE_PIN (10)        // IDC 10
+#define APPLE2_ENABLE_PIN (8)  // D6  // IDC 14
+#define APPLE2_RDDATA_PIN (7)  // D5  // IDC 16
+#define APPLE2_WRDATA_PIN (3)  // SCL // IDC 18
+#define APPLE2_PROTECT_PIN (2) // SDA // IDC 20
 #define APPLE2_INDEX_PIN  (A3)
 
 #ifndef USE_TINYUSB
@@ -412,6 +412,7 @@ void loop() {
     }
 
     Serial1.printf("Reading flux0rs on track %d: %u ticks and %d revs\n\r", floppy->track(), flux_ticks, revs);
+    Serial1.printf("Sample freqency %.1fMHz\n", floppy->getSampleFrequency() / 1e6);
     uint16_t capture_ms = 0;
     uint16_t capture_revs = 0;
     if (flux_ticks) {

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -426,7 +426,7 @@ void loop() {
     reply_buffer[i++] = GW_ACK_OK;
     Serial.write(reply_buffer, 2);
     while (revs--) {
-      uint32_t index_offset;
+      int32_t index_offset;
       // read in greaseweazle mode (long pulses encoded with 250's)
       captured_pulses = floppy->capture_track(flux_transitions, sizeof(flux_transitions),
                                               &index_offset, true, capture_ms);
@@ -446,8 +446,8 @@ void loop() {
 
       uint8_t *flux_ptr = flux_transitions;
       // send all data until the flux transition
-      while (index_offset) {
-        uint32_t to_send = min(index_offset, (uint32_t)256);
+      while (index_offset > 0 && captured_pulses > 0) {
+        int32_t to_send = min(captured_pulses, min(index_offset, (int32_t)256));
         Serial.write(flux_ptr, to_send);
         //Serial1.println(to_send);
         flux_ptr += to_send;

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -1150,7 +1150,7 @@ bool Adafruit_Apple2Floppy::get_write_protect(void) {
   delay(1);
 
   // only now can we read the protect pin status
-  bool result = !digitalRead(_protectpin);
+  bool result = digitalRead(_protectpin);
 
   // Return to where we were before...!
   goto_quartertrack(t);

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -1141,7 +1141,7 @@ bool Adafruit_Apple2Floppy::get_write_protect(void) {
   auto t = quartertrack();
   // we need to be on an even-numbered track, so that activating the "phase 1"
   // winding doesn't pull out of position. We'll return to the right spot below.
-  goto_quartertrack(t & ~3);
+  goto_quartertrack(t & ~7);
 
   // goto_track() has deenergized all windings, we need to enable phase1
   // temporarily

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -1161,7 +1161,8 @@ bool Adafruit_Apple2Floppy::get_write_protect(void) {
 /**************************************************************************/
 /*!
     @brief  Set the density for flux reading and writing
-    @param high_density true to select high density, false to select low density.
+    @param high_density true to select high density, false to select low
+   density.
     @return true if low density mode is selected, false if high density is
    selected
     @note The drive hardware is only capable of single density operation

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -513,7 +513,7 @@ uint32_t Adafruit_FloppyBase::getSampleFrequency(void) {
 /**************************************************************************/
 uint32_t Adafruit_FloppyBase::capture_track(volatile uint8_t *pulses,
                                             uint32_t max_pulses,
-                                            uint32_t *falling_index_offset,
+                                            int32_t *falling_index_offset,
                                             bool store_greaseweazle,
                                             uint32_t capture_ms) {
   memset((void *)pulses, 0, max_pulses); // zero zem out

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -427,7 +427,7 @@ bool Adafruit_Floppy::get_write_protect(void) {
   if (_protectpin == -1) {
     return false;
   }
-  return digitalRead(_protectpin);
+  return !digitalRead(_protectpin);
 }
 
 bool Adafruit_Floppy::get_track0_sense(void) {

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -1082,7 +1082,7 @@ void Adafruit_Apple2Floppy::_step(int direction, int count) {
     debug_serial->printf("Step by %d x %d\n", direction, count);
   for (; count--;) {
     _quartertrack += direction;
-    auto phase = _quartertrack % std::size(phases);
+    auto phase = _quartertrack % 8;
 
     digitalWrite(_phase1pin, phases[phase] & 8);
     digitalWrite(_phase2pin, phases[phase] & 4);

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -1161,6 +1161,7 @@ bool Adafruit_Apple2Floppy::get_write_protect(void) {
 /**************************************************************************/
 /*!
     @brief  Set the density for flux reading and writing
+    @param high_density true to select high density, false to select low density.
     @return true if low density mode is selected, false if high density is
    selected
     @note The drive hardware is only capable of single density operation

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -60,9 +60,10 @@ extern volatile bool g_writing_pulses;
 
 */
 /**************************************************************************/
-Adafruit_FloppyBase::Adafruit_FloppyBase(int indexpin, int wrdatapin, int wrgatepin, int rddatapin)
-    : _indexpin(indexpin), _wrdatapin(wrdatapin), _wrgatepin(wrgatepin), _rddatapin(rddatapin) {}
-
+Adafruit_FloppyBase::Adafruit_FloppyBase(int indexpin, int wrdatapin,
+                                         int wrgatepin, int rddatapin)
+    : _indexpin(indexpin), _wrdatapin(wrdatapin), _wrgatepin(wrgatepin),
+      _rddatapin(rddatapin) {}
 
 /**************************************************************************/
 /*!
@@ -90,8 +91,8 @@ Adafruit_Floppy::Adafruit_Floppy(int8_t densitypin, int8_t indexpin,
                                  int8_t wrdatapin, int8_t wrgatepin,
                                  int8_t track0pin, int8_t protectpin,
                                  int8_t rddatapin, int8_t sidepin,
-                                 int8_t readypin) :
-Adafruit_FloppyBase{indexpin, wrdatapin, wrgatepin, rddatapin} {
+                                 int8_t readypin)
+    : Adafruit_FloppyBase{indexpin, wrdatapin, wrgatepin, rddatapin} {
   _densitypin = densitypin;
   _selectpin = selectpin;
   _motorpin = motorpin;
@@ -162,7 +163,8 @@ void Adafruit_FloppyBase::soft_reset(void) {
 
 /**************************************************************************/
 /*!
-    @brief Disables floppy communication, allowing pins to be used for general input and output
+    @brief Disables floppy communication, allowing pins to be used for general
+   input and output
 */
 void Adafruit_FloppyBase::end(void) {
   pinMode(_rddatapin, INPUT);
@@ -213,24 +215,24 @@ void Adafruit_Floppy::soft_reset(void) {
   // set low density
   pinMode(_densitypin, OUTPUT);
   digitalWrite(_densitypin, LOW);
-
 }
 
 bool Adafruit_FloppyBase::read_index() {
 #ifdef BUSIO_USE_FAST_PINIO
-    return read_index_fast();
+  return read_index_fast();
 #else
-    if (_indexpin >= 0) {
-        return digitalRead(_indexpin);
-    } else {
-        return true;
-    }
+  if (_indexpin >= 0) {
+    return digitalRead(_indexpin);
+  } else {
+    return true;
+  }
 #endif
 }
 
 /**************************************************************************/
 /*!
-    @brief Disables floppy communication, allowing pins to be used for general input and output
+    @brief Disables floppy communication, allowing pins to be used for general
+   input and output
 */
 void Adafruit_Floppy::end(void) {
   pinMode(_selectpin, INPUT);
@@ -244,7 +246,6 @@ void Adafruit_Floppy::end(void) {
   pinMode(_densitypin, INPUT);
   Adafruit_FloppyBase::end();
 }
-
 
 /**************************************************************************/
 /*!
@@ -425,8 +426,8 @@ int8_t Adafruit_Floppy::track(void) { return _track; }
 */
 /**************************************************************************/
 uint32_t Adafruit_FloppyBase::read_track_mfm(uint8_t *sectors, size_t n_sectors,
-                                         uint8_t *sector_validity,
-                                         bool high_density) {
+                                             uint8_t *sector_validity,
+                                             bool high_density) {
   mfm_io_t io;
 
   if (high_density) {
@@ -478,10 +479,10 @@ uint32_t Adafruit_FloppyBase::getSampleFrequency(void) {
 */
 /**************************************************************************/
 uint32_t Adafruit_FloppyBase::capture_track(volatile uint8_t *pulses,
-                                        uint32_t max_pulses,
-                                        uint32_t *falling_index_offset,
-                                        bool store_greaseweazle,
-                                        uint32_t capture_ms) {
+                                            uint32_t max_pulses,
+                                            uint32_t *falling_index_offset,
+                                            bool store_greaseweazle,
+                                            uint32_t capture_ms) {
   memset((void *)pulses, 0, max_pulses); // zero zem out
 
 #if defined(ARDUINO_ARCH_RP2040)
@@ -617,7 +618,7 @@ uint32_t Adafruit_FloppyBase::capture_track(volatile uint8_t *pulses,
 */
 /**************************************************************************/
 void Adafruit_FloppyBase::write_track(uint8_t *pulses, uint32_t num_pulses,
-                                  bool store_greaseweazle) {
+                                      bool store_greaseweazle) {
 #if defined(ARDUINO_ARCH_RP2040)
   rp2040_flux_write(_indexpin, _wrgatepin, _wrdatapin, pulses,
                     pulses + num_pulses, store_greaseweazle);
@@ -742,7 +743,7 @@ void Adafruit_FloppyBase::wait_for_index_pulse_low(void) {
 */
 /**************************************************************************/
 void Adafruit_FloppyBase::print_pulses(uint8_t *pulses, uint32_t num_pulses,
-                                   bool is_gw_format) {
+                                       bool is_gw_format) {
   if (!debug_serial)
     return;
 
@@ -774,7 +775,8 @@ void Adafruit_FloppyBase::print_pulses(uint8_t *pulses, uint32_t num_pulses,
 */
 /**************************************************************************/
 void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
-                                       uint8_t max_bins, bool is_gw_format) {
+                                           uint8_t max_bins,
+                                           bool is_gw_format) {
   if (!debug_serial)
     return;
   uint32_t pulse_len = 0;
@@ -855,17 +857,14 @@ uint16_t Adafruit_FloppyBase::sample_flux(bool &index) {
 }
 
 Adafruit_Apple2Floppy::Adafruit_Apple2Floppy(int8_t indexpin, int8_t selectpin,
-                  int8_t phase1pin, int8_t phase2pin, int8_t phase3pin, int8_t phase4pin,
-                  int8_t wrdatapin, int8_t wrgatepin,
-                  int8_t protectpin, int8_t rddatapin) :
-    Adafruit_FloppyBase{indexpin, wrdatapin, wrgatepin, rddatapin},
-    _selectpin{selectpin}, _phase1pin{phase1pin},
-    _phase2pin{phase2pin},
-    _phase3pin{phase3pin},
-    _phase4pin{phase4pin},
-    _protectpin{protectpin}
-{
-}
+                                             int8_t phase1pin, int8_t phase2pin,
+                                             int8_t phase3pin, int8_t phase4pin,
+                                             int8_t wrdatapin, int8_t wrgatepin,
+                                             int8_t protectpin,
+                                             int8_t rddatapin)
+    : Adafruit_FloppyBase{indexpin, wrdatapin, wrgatepin, rddatapin},
+      _selectpin{selectpin}, _phase1pin{phase1pin}, _phase2pin{phase2pin},
+      _phase3pin{phase3pin}, _phase4pin{phase4pin}, _protectpin{protectpin} {}
 
 void Adafruit_Apple2Floppy::end() {
   pinMode(_selectpin, INPUT);
@@ -877,113 +876,139 @@ void Adafruit_Apple2Floppy::end() {
 }
 
 void Adafruit_Apple2Floppy::soft_reset() {
-    // deselect drive
-    pinMode(_selectpin, OUTPUT);
-    digitalWrite(_selectpin, HIGH);
+  Adafruit_FloppyBase::soft_reset();
 
-    // Turn off stepper motors
-    pinMode(_phase1pin, OUTPUT);
-    digitalWrite(_phase1pin, LOW);
+  // deselect drive
+  pinMode(_selectpin, OUTPUT);
+  digitalWrite(_selectpin, HIGH);
 
-    pinMode(_phase2pin, OUTPUT);
-    digitalWrite(_phase2pin, LOW);
+  // Turn off stepper motors
+  pinMode(_phase1pin, OUTPUT);
+  digitalWrite(_phase1pin, LOW);
 
-    pinMode(_phase3pin, OUTPUT);
-    digitalWrite(_phase3pin, LOW);
+  pinMode(_phase2pin, OUTPUT);
+  digitalWrite(_phase2pin, LOW);
 
-    pinMode(_phase4pin, OUTPUT);
-    digitalWrite(_phase4pin, LOW);
+  pinMode(_phase3pin, OUTPUT);
+  digitalWrite(_phase3pin, LOW);
+
+  pinMode(_phase4pin, OUTPUT);
+  digitalWrite(_phase4pin, LOW);
 }
 
 void Adafruit_Apple2Floppy::select(bool selected) {
-    digitalWrite(_selectpin, !selected);
+  digitalWrite(_selectpin, !selected);
+  Serial.printf("set selectpin %d to %d\n", _selectpin, !selected);
 }
 
 bool Adafruit_Apple2Floppy::spin_motor(bool motor_on) {
-    if(motor_on) { delayMicroseconds(motor_delay_ms); }
-    return true;
+  if (motor_on) {
+    delay(motor_delay_ms); // Main motor turn on
+
+    uint32_t index_stamp = millis();
+    bool timedout = false;
+
+    if (debug_serial)
+      debug_serial->print("Waiting for index pulse...");
+
+    while (!read_index()) {
+      if ((millis() - index_stamp) > 10000) {
+        timedout = true; // its been 10 seconds?
+        break;
+      }
+    }
+
+    while (read_index()) {
+      if ((millis() - index_stamp) > 10000) {
+        timedout = true; // its been 10 seconds?
+        break;
+      }
+    }
+
+    if (timedout) {
+      if (debug_serial)
+        debug_serial->println("Didn't find an index pulse!");
+      return false;
+    }
+    if (debug_serial)
+      debug_serial->println("Found!");
+  }
+  return true;
 }
 
 // stepping FORWARD through phases steps OUT towards SMALLER track numbers
 // stepping BACKWARD through phases steps IN towards BIGGER track numbers
 const uint8_t phases[] = {
-    0b1000,
-    0b1100,
-    0b0100,
-    0b0110,
-    0b0010,
-    0b0011,
-    0b0001,
-    0b1001,
+    0b1000, 0b1100, 0b0100, 0b0110, 0b0010, 0b0011, 0b0001, 0b1001,
 };
 
-
 enum {
-STEP_OUT_QUARTER = -1,
-STEP_OUT_HALF = -2,
-STEP_IN_HALF = 2,
-STEP_IN_QUARTER = 1,
+  STEP_OUT_QUARTER = -1,
+  STEP_OUT_HALF = -2,
+  STEP_IN_HALF = 2,
+  STEP_IN_QUARTER = 1,
 };
 
 bool Adafruit_Apple2Floppy::goto_track(uint8_t track) {
-    if (track < 0 || track > 160) {
-        return false;
-    }
-    if(_quartertrack == -1) {
-        _quartertrack = 160;
-        goto_track(0);
-    }
+  if (track < 0 || track > 160) {
+    return false;
+  }
+  if (_quartertrack == -1) {
+    _quartertrack = 160;
+    goto_track(0);
+  }
 
-    auto quartertrack = track * 4;
-    auto diff = quartertrack - this->_quartertrack;
-    
-    if(diff < 0) {
-            // step OUT to SMALLER track numbers
-            _step(STEP_OUT_QUARTER, -diff);
+  int quartertrack = track * 4;
+  int diff = quartertrack - this->_quartertrack;
+
+  if (diff != 0) {
+    if (diff < 0) {
+      // step OUT to SMALLER track numbers
+      _step(STEP_OUT_QUARTER, -diff);
     } else {
-            // step IN to LARGER track numbers
-            _step(STEP_IN_QUARTER, diff);
+      // step IN to LARGER track numbers
+      _step(STEP_IN_QUARTER, diff);
     }
     delay(settle_delay_ms);
+  }
 
-    // according to legend, Apple DOS always disables all phases after settling
-    digitalWrite(_phase1pin, 0);
-    digitalWrite(_phase2pin, 0);
-    digitalWrite(_phase3pin, 0);
-    digitalWrite(_phase4pin, 0);
-    return true;
+  // according to legend, Apple DOS always disables all phases after settling
+  digitalWrite(_phase1pin, 0);
+  digitalWrite(_phase2pin, 0);
+  digitalWrite(_phase3pin, 0);
+  digitalWrite(_phase4pin, 0);
+
+  return true;
 }
 
 void Adafruit_Apple2Floppy::_step(int direction, int count) {
-    Serial.printf("Step by %d x %d\n", direction, count);
-    for(;count--;) {
-        _quartertrack += direction;
-        auto phase = _quartertrack % std::size(phases);
-        Serial.printf("Set phases to %d%d%d%d", phases[phase] & 8, phases[phase] & 4, phases[phase] & 2, phases[phase] & 1);
+  Serial.printf("Step by %d x %d\n", direction, count);
+  for (; count--;) {
+    _quartertrack += direction;
+    auto phase = _quartertrack % std::size(phases);
 
-        digitalWrite(_phase1pin, phases[phase] & 8);
-        digitalWrite(_phase2pin, phases[phase] & 4);
-        digitalWrite(_phase3pin, phases[phase] & 2);
-        digitalWrite(_phase4pin, phases[phase] & 1);
-        delay((step_delay_us / 1000UL) + 1); // round up to at least 1ms
-    }
+    digitalWrite(_phase1pin, phases[phase] & 8);
+    digitalWrite(_phase2pin, phases[phase] & 4);
+    digitalWrite(_phase3pin, phases[phase] & 2);
+    digitalWrite(_phase4pin, phases[phase] & 1);
+    delay((step_delay_us / 1000UL) + 1); // round up to at least 1ms
+  }
 }
 
 void Adafruit_Apple2Floppy::side(uint8_t head) {}
 
-int8_t Adafruit_Apple2Floppy::track(void) {
-    return _quartertrack / 4;
-}
+int8_t Adafruit_Apple2Floppy::track(void) { return _quartertrack / 4; }
 
 // The write protect circuit in the Apple II floppy drive is "interesting".
 // Because of how it was read by the Apple II Disk Interface Card, the protect
 // output is only active when the "phase 1" winding is energized;
 // having the "phase 1" winding active also prevents writing, but at the Disk
-// Interface Card, not at the drive. So, it's necessary for us to check write_protected in software!
+// Interface Card, not at the drive. So, it's necessary for us to check
+// write_protected in software!
 bool Adafruit_Apple2Floppy::write_protected(void) {
-    digitalWrite(_phase1pin, 1);
-    bool result = !digitalRead(_protectpin);
-    digitalWrite(_phase1pin, 0);
-    delay(settle_delay_ms);
-    return result;
+  digitalWrite(_phase1pin, 1);
+  bool result = !digitalRead(_protectpin);
+  digitalWrite(_phase1pin, 0);
+  delay(settle_delay_ms);
+  return result;
 }

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -39,7 +39,7 @@ protected:
   Adafruit_FloppyBase(int indexpin, int wrdatapin, int wrgatepin, int rddatapin);
 
 public:
-  virtual bool begin(void);
+  bool begin(void);
   virtual void end();
 
   virtual void soft_reset(void);
@@ -49,7 +49,6 @@ public:
   virtual bool goto_track(uint8_t track) = 0;
   virtual void side(uint8_t head) = 0;
   virtual int8_t track(void) = 0;
-  virtual void step(bool dir, uint8_t times) = 0;
     
   uint32_t read_track_mfm(uint8_t *sectors, size_t n_sectors,
                           uint8_t *sector_validity, bool high_density = true);
@@ -135,7 +134,7 @@ public:
   bool goto_track(uint8_t track) override;
   void side(uint8_t head) override;
   int8_t track(void) override;
-  void step(bool dir, uint8_t times) override;
+  void step(bool dir, uint8_t times);
 
   // theres a lot of GPIO!
   int8_t _densitypin, _selectpin, _motorpin, _directionpin, _steppin,
@@ -143,6 +142,33 @@ public:
 
 private:
   int8_t _track = -1;
+};
+
+/**************************************************************************/
+/*!
+    @brief A helper class for chattin with Apple 2 floppy drives
+*/
+/**************************************************************************/
+class Adafruit_Apple2Floppy : public Adafruit_FloppyBase {
+  Adafruit_Apple2Floppy(int8_t indexpin, int8_t selectpin,
+                  int8_t phase1pin, int8_t phase2pin, int8_t phase3pin, int8_t phase4pin,
+                  int8_t wrdatapin, int8_t wrgatepin,
+                  int8_t protectpin, int8_t rddatapin);
+  void end() override;
+  void soft_reset(void) override;
+
+  void select(bool selected) override;
+  bool spin_motor(bool motor_on) override;
+  bool goto_track(uint8_t track) override;
+  void side(uint8_t head) override;
+  int8_t track(void) override;
+  bool write_protected(void);
+
+private:
+  // theres not much GPIO!
+  int8_t _selectpin, _phase1pin, _phase2pin, _phase3pin, _phase4pin, _protectpin;
+  int8_t _quartertrack = -1;
+  void _step(int dir, int times);
 };
 
 /**************************************************************************/

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -116,7 +116,7 @@ public:
   uint32_t read_track_mfm(uint8_t *sectors, size_t n_sectors,
                           uint8_t *sector_validity, bool high_density = true);
   uint32_t capture_track(volatile uint8_t *pulses, uint32_t max_pulses,
-                         uint32_t *falling_index_offset,
+                         int32_t *falling_index_offset,
                          bool store_greaseweazle = false,
                          uint32_t capture_ms = 0)
       __attribute__((optimize("O3")));

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -36,7 +36,8 @@ typedef enum {
 /**************************************************************************/
 class Adafruit_FloppyBase {
 protected:
-  Adafruit_FloppyBase(int indexpin, int wrdatapin, int wrgatepin, int rddatapin);
+  Adafruit_FloppyBase(int indexpin, int wrdatapin, int wrgatepin,
+                      int rddatapin);
 
 public:
   bool begin(void);
@@ -49,7 +50,7 @@ public:
   virtual bool goto_track(uint8_t track) = 0;
   virtual void side(uint8_t head) = 0;
   virtual int8_t track(void) = 0;
-    
+
   uint32_t read_track_mfm(uint8_t *sectors, size_t n_sectors,
                           uint8_t *sector_validity, bool high_density = true);
   uint32_t capture_track(volatile uint8_t *pulses, uint32_t max_pulses,
@@ -110,7 +111,7 @@ private:
 #ifdef BUSIO_USE_FAST_PINIO
   BusIO_PortReg *indexPort;
   BusIO_PortMask indexMask;
-  uint32_t dummyPort=0;
+  uint32_t dummyPort = 0;
 #endif
 };
 
@@ -150,10 +151,11 @@ private:
 */
 /**************************************************************************/
 class Adafruit_Apple2Floppy : public Adafruit_FloppyBase {
-  Adafruit_Apple2Floppy(int8_t indexpin, int8_t selectpin,
-                  int8_t phase1pin, int8_t phase2pin, int8_t phase3pin, int8_t phase4pin,
-                  int8_t wrdatapin, int8_t wrgatepin,
-                  int8_t protectpin, int8_t rddatapin);
+public:
+  Adafruit_Apple2Floppy(int8_t indexpin, int8_t selectpin, int8_t phase1pin,
+                        int8_t phase2pin, int8_t phase3pin, int8_t phase4pin,
+                        int8_t wrdatapin, int8_t wrgatepin, int8_t protectpin,
+                        int8_t rddatapin);
   void end() override;
   void soft_reset(void) override;
 
@@ -166,7 +168,8 @@ class Adafruit_Apple2Floppy : public Adafruit_FloppyBase {
 
 private:
   // theres not much GPIO!
-  int8_t _selectpin, _phase1pin, _phase2pin, _phase3pin, _phase4pin, _protectpin;
+  int8_t _selectpin, _phase1pin, _phase2pin, _phase3pin, _phase4pin,
+      _protectpin;
   int8_t _quartertrack = -1;
   void _step(int dir, int times);
 };

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -45,10 +45,44 @@ public:
 
   virtual void soft_reset(void);
 
+  /**************************************************************************/
+  /*!
+      @brief Whether to select this drive
+      @param selected True to select/enable
+  */
+  /**************************************************************************/
   virtual void select(bool selected) = 0;
+  /**************************************************************************/
+  /*!
+      @brief  Turn on or off the floppy motor, if on we wait till we get an
+     index pulse!
+      @param motor_on True to turn on motor, False to turn it off
+      @returns False if turning motor on and no index pulse found, true
+     otherwise
+  */
+  /**************************************************************************/
   virtual bool spin_motor(bool motor_on) = 0;
-  virtual bool goto_track(uint8_t track) = 0;
+  /**************************************************************************/
+  /*!
+      @brief  Seek to the desired track, requires the motor to be spun up!
+      @param  track_num The track to step to
+      @return True If we were able to get to the track location
+  */
+  /**************************************************************************/
+  virtual bool goto_track(uint8_t track_num) = 0;
+  /**************************************************************************/
+  /*!
+      @brief Which head/side to read from
+      @param head Head 0 or 1
+  */
+  /**************************************************************************/
   virtual void side(uint8_t head) = 0;
+  /**************************************************************************/
+  /*!
+      @brief  The current track location, based on internal caching
+      @return The cached track location
+  */
+  /**************************************************************************/
   virtual int8_t track(void) = 0;
 
   uint32_t read_track_mfm(uint8_t *sectors, size_t n_sectors,
@@ -137,11 +171,11 @@ public:
   int8_t track(void) override;
   void step(bool dir, uint8_t times);
 
+private:
   // theres a lot of GPIO!
   int8_t _densitypin, _selectpin, _motorpin, _directionpin, _steppin,
       _track0pin, _protectpin, _sidepin, _readypin;
 
-private:
   int8_t _track = -1;
 };
 

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -217,10 +217,15 @@ private:
 /**************************************************************************/
 class Adafruit_Apple2Floppy : public Adafruit_FloppyBase {
 public:
+  /**************************************************************************/
+  /*!
+      @brief Constants for use with the step_mode method
+  */
+  /**************************************************************************/
   enum StepMode {
-    STEP_MODE_WHOLE,
-    STEP_MODE_HALF,
-    STEP_MODE_QUARTER,
+    STEP_MODE_WHOLE,   //< One step moves by one data track
+    STEP_MODE_HALF,    //< Two steps move by one data track
+    STEP_MODE_QUARTER, //< Four steps move by one data track
   };
 
   Adafruit_Apple2Floppy(int8_t indexpin, int8_t selectpin, int8_t phase1pin,

--- a/src/arch_rp2.cpp
+++ b/src/arch_rp2.cpp
@@ -355,12 +355,12 @@ uint32_t rp2040_flux_capture(int index_pin, int rdpin, volatile uint8_t *pulses,
 }
 
 unsigned _last = ~0u;
-bool Adafruit_Floppy::init_capture(void) {
+bool Adafruit_FloppyBase::init_capture(void) {
   _last = ~0u;
   return ::init_capture(_indexpin, _rddatapin);
 }
 
-bool Adafruit_Floppy::start_polled_capture(void) {
+bool Adafruit_FloppyBase::start_polled_capture(void) {
   if (!init_capture())
     return false;
   start_common();
@@ -368,7 +368,7 @@ bool Adafruit_Floppy::start_polled_capture(void) {
   return true;
 }
 
-void Adafruit_Floppy::disable_capture(void) { ::disable_capture(); }
+void Adafruit_FloppyBase::disable_capture(void) { ::disable_capture(); }
 
 uint16_t mfm_io_sample_flux(bool *index) {
   if (_last == ~0u) {

--- a/src/arch_rp2.cpp
+++ b/src/arch_rp2.cpp
@@ -224,7 +224,7 @@ static uint8_t *capture_foreground(int index_pin, uint8_t *start, uint8_t *end,
 
   disable_capture();
 
-  return start;
+  return ptr;
 }
 
 static void enable_capture_fifo() { start_common(); }

--- a/src/arch_rp2.cpp
+++ b/src/arch_rp2.cpp
@@ -163,12 +163,12 @@ static void free_capture(void) {
 }
 
 static uint8_t *capture_foreground(int index_pin, uint8_t *start, uint8_t *end,
-                                   uint32_t *falling_index_offset,
+                                   int32_t *falling_index_offset,
                                    bool store_greaseweazle,
                                    uint32_t capture_counts) {
   uint8_t *ptr = start;
   if (falling_index_offset) {
-    *falling_index_offset = ~0u;
+    *falling_index_offset = -1;
   }
   start_common();
 
@@ -340,7 +340,7 @@ static void free_write() {
 
 uint32_t rp2040_flux_capture(int index_pin, int rdpin, volatile uint8_t *pulses,
                              volatile uint8_t *pulse_end,
-                             uint32_t *falling_index_offset,
+                             int32_t *falling_index_offset,
                              bool store_greaseweazle, uint32_t capture_counts) {
   if (!init_capture(index_pin, rdpin)) {
     return 0;

--- a/src/arch_rp2.cpp
+++ b/src/arch_rp2.cpp
@@ -293,6 +293,8 @@ static void write_foreground(int index_pin, int wrgate_pin, uint8_t *pulses,
   pinMode(wrgate_pin, OUTPUT);
   digitalWrite(wrgate_pin, LOW);
 
+  noInterrupts();
+  pio_sm_set_enabled(g_writer.pio, g_writer.sm, false);
   pio_sm_clear_fifos(g_writer.pio, g_writer.sm);
   pio_sm_exec(g_writer.pio, g_writer.sm, g_writer.offset);
   while (!pio_sm_is_tx_fifo_full(g_writer.pio, g_writer.sm)) {
@@ -302,7 +304,6 @@ static void write_foreground(int index_pin, int wrgate_pin, uint8_t *pulses,
   }
   pio_sm_set_enabled(g_writer.pio, g_writer.sm, true);
 
-  noInterrupts();
   bool old_index_state = false;
   int i = 0;
   while (pulses != pulse_end) {

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -1,6 +1,6 @@
 #pragma once
 #if defined(ARDUINO_ARCH_RP2040)
-#define read_index() gpio_get(_indexpin)
+#define read_index_fast() gpio_get(_indexpin)
 #define read_data() gpio_get(_rddatapin)
 #define set_debug_led() gpio_put(led_pin, 1)
 #define clr_debug_led() gpio_put(led_pin, 0)

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 extern uint32_t
 rp2040_flux_capture(int indexpin, int rdpin, volatile uint8_t *pulses,
-                    volatile uint8_t *end, uint32_t *falling_index_offset,
+                    volatile uint8_t *end, int32_t *falling_index_offset,
                     bool store_greaseweazle, uint32_t capture_counts);
 extern void rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
                               uint8_t *pulses, uint8_t *pulse_end,

--- a/src/arch_samd51.cpp
+++ b/src/arch_samd51.cpp
@@ -424,7 +424,7 @@ bool Adafruit_FloppyBase::start_polled_capture(void) {
 
 uint16_t mfm_io_sample_flux(bool *index) {
   if (!theReadTimer)
-    return ~0u;
+    return ~(uint16_t)0;
 
   // Check for match counter 0 (MC0) interrupt
   while (!(theReadTimer->COUNT16.INTFLAG.bit.MC0)) {

--- a/src/arch_samd51.cpp
+++ b/src/arch_samd51.cpp
@@ -369,11 +369,11 @@ static void enable_generate_timer(void) {
 
 #ifdef __cplusplus
 
-bool Adafruit_Floppy::init_capture(void) {
+bool Adafruit_FloppyBase::init_capture(void) {
   return init_capture_timer(_rddatapin, debug_serial);
 }
 
-void Adafruit_Floppy::deinit_capture(void) {
+void Adafruit_FloppyBase::deinit_capture(void) {
   if (!theReadTimer)
     return;
 
@@ -384,20 +384,20 @@ void Adafruit_Floppy::deinit_capture(void) {
   theReadTimer = NULL;
 }
 
-void Adafruit_Floppy::enable_capture(void) { enable_capture_timer(true); }
+void Adafruit_FloppyBase::enable_capture(void) { enable_capture_timer(true); }
 
-void Adafruit_Floppy::disable_capture(void) {
+void Adafruit_FloppyBase::disable_capture(void) {
   if (!theReadTimer)
     return;
 
   theReadTimer->COUNT16.CTRLA.bit.ENABLE = 0; // disable the TC timer
 }
 
-bool Adafruit_Floppy::init_generate(void) {
+bool Adafruit_FloppyBase::init_generate(void) {
   return init_generate_timer(_wrdatapin, debug_serial);
 }
 
-void Adafruit_Floppy::deinit_generate(void) {
+void Adafruit_FloppyBase::deinit_generate(void) {
   if (!theWriteTimer)
     return;
 
@@ -408,16 +408,16 @@ void Adafruit_Floppy::deinit_generate(void) {
   theWriteTimer = NULL;
 }
 
-void Adafruit_Floppy::enable_generate(void) { enable_generate_timer(); }
+void Adafruit_FloppyBase::enable_generate(void) { enable_generate_timer(); }
 
-void Adafruit_Floppy::disable_generate(void) {
+void Adafruit_FloppyBase::disable_generate(void) {
   if (!theWriteTimer)
     return;
 
   theWriteTimer->COUNT16.CTRLA.bit.ENABLE = 0; // disable the TC timer
 }
 
-bool Adafruit_Floppy::start_polled_capture(void) {
+bool Adafruit_FloppyBase::start_polled_capture(void) {
   ::enable_capture_timer(false);
   return true;
 }


### PR DESCRIPTION
This adds support for the Apple II 5.25" floppy drives, as long as you've modified them to add a revolution sensor. 
Write protect is weird and untested. Writing is untested. Works with fluxengine pending a PR:
 * https://github.com/davidgiven/fluxengine/pull/492