### PR TITLE
Add Apple Disk ][ Flux Writing for rp2040

### DIFF
--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -497,8 +497,6 @@ void loop() {
     } else {
       //uint8_t cue_at_index = cmd_buffer[2];
       //uint8_t terminate_at_index = cmd_buffer[3];
-      reply_buffer[i++] = GW_ACK_OK;
-      Serial.write(reply_buffer, 2);
 
       uint32_t fluxors = 0;
       uint8_t flux = 0xFF;
@@ -511,9 +509,12 @@ void loop() {
         Serial1.println("*** FLUX OVERRUN ***");
         while (1) yield();
       }
-      floppy->write_track(flux_transitions, fluxors - 7, true);
+      bool result = floppy->write_track(flux_transitions, fluxors - 7, true);
       Serial1.println("wrote fluxors");
       Serial.write((byte)0);
+
+      reply_buffer[i++] = result ? GW_ACK_OK : GW_ACK_WRPROT;
+      Serial.write(reply_buffer, 2);
     }
   }
   else if (cmd == GW_CMD_GETFLUXSTATUS) {

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -48,6 +48,7 @@ extern volatile bool g_writing_pulses;
     @param  wrdatapin A pin connected to the floppy Write Data input
     @param  wrgatepin A pin connected to the floppy Write Gate input
     @param  rddatapin A pin connected to the floppy Read Data output
+    @param  is_apple2 True if the flux write waveform is like Apple Disk ][
 
 */
 /**************************************************************************/

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -699,6 +699,7 @@ bool Adafruit_FloppyBase::write_track(uint8_t *pulses, uint32_t num_pulses,
   disable_generate();
   deinit_generate();
 
+  return true;
 #else // bitbang it!
   if (_is_apple2) {
     return false;

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -650,6 +650,8 @@ uint32_t Adafruit_FloppyBase::capture_track(volatile uint8_t *pulses,
     @param  pulses An array of timer-count pulses
     @param  num_pulses How many bytes are in the pulse array
     @param  store_greaseweazle If true, long pulses are 'packed' in gw format
+    @returns False if the data could not be written (samd51 cannot write apple
+   flux format)
 */
 /**************************************************************************/
 bool Adafruit_FloppyBase::write_track(uint8_t *pulses, uint32_t num_pulses,

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -36,8 +36,8 @@ typedef enum {
 /**************************************************************************/
 class Adafruit_FloppyBase {
 protected:
-  Adafruit_FloppyBase(int indexpin, int wrdatapin, int wrgatepin,
-                      int rddatapin);
+  Adafruit_FloppyBase(int indexpin, int wrdatapin, int wrgatepin, int rddatapin,
+                      bool is_apple2 = false);
 
 public:
   bool begin(void);
@@ -121,7 +121,7 @@ public:
                          uint32_t capture_ms = 0)
       __attribute__((optimize("O3")));
 
-  void write_track(uint8_t *pulses, uint32_t num_pulses,
+  bool write_track(uint8_t *pulses, uint32_t num_pulses,
                    bool store_greaseweazle = false)
       __attribute__((optimize("O3")));
   void print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
@@ -169,6 +169,7 @@ private:
   void wait_for_index_pulse_low(void);
 
   int8_t _indexpin, _wrdatapin, _wrgatepin, _rddatapin;
+  bool _is_apple2;
 
 #ifdef BUSIO_USE_FAST_PINIO
   BusIO_PortReg *indexPort;

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -11,7 +11,7 @@ extern uint32_t
 rp2040_flux_capture(int indexpin, int rdpin, volatile uint8_t *pulses,
                     volatile uint8_t *end, int32_t *falling_index_offset,
                     bool store_greaseweazle, uint32_t capture_counts);
-extern void rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
+extern bool rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
                               uint8_t *pulses, uint8_t *pulse_end,
-                              bool store_greaseweazel);
+                              bool store_greaseweazel, bool is_apple2);
 #endif


### PR DESCRIPTION
The Apple Disk ][ produces a flux transition whenever the WRDATA signal has a transition, rather than on only one edge. This needs different low-level writing code than a PC drive.

We can implement it later for samd51 or bitbang if needed.

The original version was tested on HW but the compatible version hasn't been tested yet.

![image](https://user-images.githubusercontent.com/1517291/160887039-79e3bd51-bc0a-4058-9223-e10407a3c0a9.png)
