### PR TITLE
Drop the QUARTERTRACK type, APPLE2 is always quarter-track

### DIFF
--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -113,7 +113,6 @@ uint8_t cmd_buff_idx = 0;
 #define GW_CMD_SETBUSTYPE_IBM 1
 #define GW_CMD_SETBUSTYPE_SHUGART 2
 #define GW_CMD_SETBUSTYPE_APPLE2 3
-#define GW_CMD_SETBUSTYPE_APPLE2_QUARTERTRACK 4
 #define GW_CMD_SETPIN    15
 #define GW_CMD_SETPIN_DENSITY 2
 #define GW_CMD_RESET     16
@@ -148,11 +147,7 @@ bool setbustype(int bustype) {
 #ifdef APPLE2_RDDATA_PIN
     case GW_CMD_SETBUSTYPE_APPLE2:
       floppy = &apple2floppy;
-      apple2floppy.step_mode(Adafruit_Apple2Floppy::STEP_MODE_HALF);
-      break;
-    case GW_CMD_SETBUSTYPE_APPLE2_QUARTERTRACK:
       apple2floppy.step_mode(Adafruit_Apple2Floppy::STEP_MODE_QUARTER);
-      floppy = &apple2floppy;
       break;
 #endif
     default:


### PR DESCRIPTION
GW and FluxEngine folks agreed that it is better to just always use the drive's native step, and FluxEngine has started fixing things internally so that this works better than when I first implemented the "why not both" approach.  Only the "3" bustype is allocated now in the GW protocol.

We can decide if we want to keep the step_mode at all, since its only intended user was the GW-compatible firmware.
