### PR TITLE
Update featherwing pinout

### DIFF
--- a/examples/fat_test/fat_test.ino
+++ b/examples/fat_test/fat_test.ino
@@ -12,49 +12,54 @@
 #include "SdFat.h"
 #include <Adafruit_Floppy.h>
 
-// If using SAMD51, turn on TINYUSB USB stack
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      A4    // IDC 18
-#define STEP_PIN     A5    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      24    // IDC 18
-#define STEP_PIN     25    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      8    // IDC 32
-#define READY_PIN     7    // IDC 34
-#elif defined (ARDUINO_RASPBERRY_PI_PICO)
-#define DENSITY_PIN  2     // IDC 2
-#define INDEX_PIN    3     // IDC 8
-#define SELECT_PIN   4     // IDC 12
-#define MOTOR_PIN    5     // IDC 16
-#define DIR_PIN      6     // IDC 18
-#define STEP_PIN     7     // IDC 20
-#define WRDATA_PIN   8     // IDC 22 (not used during read)
-#define WRGATE_PIN   9     // IDC 24 (not used during read)
-#define TRK0_PIN    10     // IDC 26
-#define PROT_PIN    11     // IDC 28
-#define READ_PIN    12     // IDC 30
-#define SIDE_PIN    13     // IDC 32
-#define READY_PIN   14     // IDC 34
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN A5   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN A4    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 6     // IDC 32
+#define READY_PIN 5    // IDC 34
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN 25   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN 24    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 8     // IDC 32
+#define READY_PIN 7    // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#elif defined(ARDUINO_RASPBERRY_PI_PICO)
+#define DENSITY_PIN 2 // IDC 2
+#define INDEX_PIN 3   // IDC 8
+#define SELECT_PIN 4  // IDC 12
+#define MOTOR_PIN 5   // IDC 16
+#define DIR_PIN 6     // IDC 18
+#define STEP_PIN 7    // IDC 20
+#define WRDATA_PIN 8  // IDC 22 (not used during read)
+#define WRGATE_PIN 9  // IDC 24 (not used during read)
+#define TRK0_PIN 10   // IDC 26
+#define PROT_PIN 11   // IDC 28
+#define READ_PIN 12   // IDC 30
+#define SIDE_PIN 13   // IDC 32
+#define READY_PIN 14  // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
 #else
 #error "Please set up pin definitions!"
 #endif

--- a/examples/floppy_capture_track_test/floppy_capture_track_test.ino
+++ b/examples/floppy_capture_track_test/floppy_capture_track_test.ino
@@ -1,48 +1,53 @@
 #include <Adafruit_Floppy.h>
 
-// If using SAMD51, turn on TINYUSB USB stack
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      A4    // IDC 18
-#define STEP_PIN     A5    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      24    // IDC 18
-#define STEP_PIN     25    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_RASPBERRY_PI_PICO)
-#define DENSITY_PIN  2     // IDC 2
-#define INDEX_PIN    3     // IDC 8
-#define SELECT_PIN   4     // IDC 12
-#define MOTOR_PIN    5     // IDC 16
-#define DIR_PIN      6     // IDC 18
-#define STEP_PIN     7     // IDC 20
-#define WRDATA_PIN   8     // IDC 22 (not used during read)
-#define WRGATE_PIN   9     // IDC 24 (not used during read)
-#define TRK0_PIN    10     // IDC 26
-#define PROT_PIN    11     // IDC 28
-#define READ_PIN    12     // IDC 30
-#define SIDE_PIN    13     // IDC 32
-#define READY_PIN   14     // IDC 34
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN A5   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN A4    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 6     // IDC 32
+#define READY_PIN 5    // IDC 34
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN 25   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN 24    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 8     // IDC 32
+#define READY_PIN 7    // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#elif defined(ARDUINO_RASPBERRY_PI_PICO)
+#define DENSITY_PIN 2 // IDC 2
+#define INDEX_PIN 3   // IDC 8
+#define SELECT_PIN 4  // IDC 12
+#define MOTOR_PIN 5   // IDC 16
+#define DIR_PIN 6     // IDC 18
+#define STEP_PIN 7    // IDC 20
+#define WRDATA_PIN 8  // IDC 22 (not used during read)
+#define WRGATE_PIN 9  // IDC 24 (not used during read)
+#define TRK0_PIN 10   // IDC 26
+#define PROT_PIN 11   // IDC 28
+#define READ_PIN 12   // IDC 30
+#define SIDE_PIN 13   // IDC 32
+#define READY_PIN 14  // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
 #else
 #error "Please set up pin definitions!"
 #endif

--- a/examples/floppy_write_test/floppy_write_test.ino
+++ b/examples/floppy_write_test/floppy_write_test.ino
@@ -1,48 +1,53 @@
 #include <Adafruit_Floppy.h>
 
-// If using SAMD51, turn on TINYUSB USB stack
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      A4    // IDC 18
-#define STEP_PIN     A5    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      24    // IDC 18
-#define STEP_PIN     25    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_RASPBERRY_PI_PICO)
-#define DENSITY_PIN  2     // IDC 2
-#define INDEX_PIN    3     // IDC 8
-#define SELECT_PIN   4     // IDC 12
-#define MOTOR_PIN    5     // IDC 16
-#define DIR_PIN      6     // IDC 18
-#define STEP_PIN     7     // IDC 20
-#define WRDATA_PIN   8     // IDC 22 (not used during read)
-#define WRGATE_PIN   9     // IDC 24 (not used during read)
-#define TRK0_PIN    10     // IDC 26
-#define PROT_PIN    11     // IDC 28
-#define READ_PIN    12     // IDC 30
-#define SIDE_PIN    13     // IDC 32
-#define READY_PIN   14     // IDC 34
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN A5   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN A4    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 6     // IDC 32
+#define READY_PIN 5    // IDC 34
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN 25   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN 24    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 8     // IDC 32
+#define READY_PIN 7    // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#elif defined(ARDUINO_RASPBERRY_PI_PICO)
+#define DENSITY_PIN 2 // IDC 2
+#define INDEX_PIN 3   // IDC 8
+#define SELECT_PIN 4  // IDC 12
+#define MOTOR_PIN 5   // IDC 16
+#define DIR_PIN 6     // IDC 18
+#define STEP_PIN 7    // IDC 20
+#define WRDATA_PIN 8  // IDC 22 (not used during read)
+#define WRGATE_PIN 9  // IDC 24 (not used during read)
+#define TRK0_PIN 10   // IDC 26
+#define PROT_PIN 11   // IDC 28
+#define READ_PIN 12   // IDC 30
+#define SIDE_PIN 13   // IDC 32
+#define READY_PIN 14  // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
 #else
 #error "Please set up pin definitions!"
 #endif

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -1,34 +1,59 @@
 #include <Adafruit_Floppy.h>
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      A4    // IDC 18
-#define STEP_PIN     A5    // IDC 20
-#define WRDATA_PIN   13    // IDC 22
-#define WRGATE_PIN   12    // IDC 24
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      24    // IDC 18
-#define STEP_PIN     25    // IDC 20
-#define WRDATA_PIN   13    // IDC 22
-#define WRGATE_PIN   12    // IDC 24
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      8    // IDC 32
-#define READY_PIN     7    // IDC 34
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN A5   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN A4    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 6     // IDC 32
+#define READY_PIN 5    // IDC 34
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN 25   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN 24    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 8     // IDC 32
+#define READY_PIN 7    // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#elif defined(ARDUINO_RASPBERRY_PI_PICO)
+#define DENSITY_PIN 2 // IDC 2
+#define INDEX_PIN 3   // IDC 8
+#define SELECT_PIN 4  // IDC 12
+#define MOTOR_PIN 5   // IDC 16
+#define DIR_PIN 6     // IDC 18
+#define STEP_PIN 7    // IDC 20
+#define WRDATA_PIN 8  // IDC 22 (not used during read)
+#define WRGATE_PIN 9  // IDC 24 (not used during read)
+#define TRK0_PIN 10   // IDC 26
+#define PROT_PIN 11   // IDC 28
+#define READ_PIN 12   // IDC 30
+#define SIDE_PIN 13   // IDC 32
+#define READY_PIN 14  // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#else
+#error "Please set up pin definitions!"
+#endif
 
+
+#if defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
 // jepler's prototype board, subject to change
 #define APPLE2_PHASE1_PIN (A2)        // IDC 2
 #define APPLE2_PHASE2_PIN (13)        // IDC 4
@@ -40,29 +65,6 @@
 #define APPLE2_WRDATA_PIN (3)  // SCL // IDC 18
 #define APPLE2_PROTECT_PIN (2) // SDA // IDC 20
 #define APPLE2_INDEX_PIN  (A3)
-
-#ifndef USE_TINYUSB
-#error "Please set Adafruit TinyUSB under Tools > USB Stack"
-#endif
-#elif defined (ARDUINO_RASPBERRY_PI_PICO)
-#define DENSITY_PIN  2     // IDC 2
-#define INDEX_PIN    3     // IDC 8
-#define SELECT_PIN   4     // IDC 12
-#define MOTOR_PIN    5     // IDC 16
-#define DIR_PIN      6     // IDC 18
-#define STEP_PIN     7     // IDC 20
-#define WRDATA_PIN   8     // IDC 22 (not used during read)
-#define WRGATE_PIN   9     // IDC 24 (not used during read)
-#define TRK0_PIN    10     // IDC 26
-#define PROT_PIN    11     // IDC 28
-#define READ_PIN    12     // IDC 30
-#define SIDE_PIN    13     // IDC 32
-#define READY_PIN   14     // IDC 34
-#ifndef USE_TINYUSB
-#error "Please set Adafruit TinyUSB under Tools > USB Stack"
-#endif
-#else
-#error "Please set up pin definitions!"
 #endif
 
 #ifdef READ_PIN
@@ -71,14 +73,14 @@ Adafruit_Floppy pcfloppy(DENSITY_PIN, INDEX_PIN, SELECT_PIN,
                          WRDATA_PIN, WRGATE_PIN, TRK0_PIN,
                          PROT_PIN, READ_PIN, SIDE_PIN, READY_PIN);
 #else
-#warning "This firmware will not support PC/Shugart drives"
+#pragma message "This firmware will not support PC/Shugart drives"
 #endif
 #ifdef APPLE2_RDDATA_PIN
 Adafruit_Apple2Floppy apple2floppy(APPLE2_INDEX_PIN, APPLE2_ENABLE_PIN,
                                    APPLE2_PHASE1_PIN, APPLE2_PHASE2_PIN, APPLE2_PHASE3_PIN, APPLE2_PHASE4_PIN,
                                    APPLE2_WRDATA_PIN, APPLE2_WRGATE_PIN, APPLE2_PROTECT_PIN, APPLE2_RDDATA_PIN);
 #else
-#warning "This firmware will not support Apple ][ drives"
+#pragma message "This firmware will not support Apple ][ drives"
 #endif
 
 Adafruit_FloppyBase *floppy;

--- a/examples/mfm_test/mfm_test.ino
+++ b/examples/mfm_test/mfm_test.ino
@@ -1,53 +1,57 @@
 #include <Adafruit_Floppy.h>
 
-
-
-// If using SAMD51, turn on TINYUSB USB stack
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      A4    // IDC 18
-#define STEP_PIN     A5    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      24    // IDC 18
-#define STEP_PIN     25    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      8    // IDC 32
-#define READY_PIN     7    // IDC 34
-#elif defined (ARDUINO_RASPBERRY_PI_PICO)
-#define DENSITY_PIN  2     // IDC 2
-#define INDEX_PIN    3     // IDC 8
-#define SELECT_PIN   4     // IDC 12
-#define MOTOR_PIN    5     // IDC 16
-#define DIR_PIN      6     // IDC 18
-#define STEP_PIN     7     // IDC 20
-#define WRDATA_PIN   8     // IDC 22 (not used during read)
-#define WRGATE_PIN   9     // IDC 24 (not used during read)
-#define TRK0_PIN    10     // IDC 26
-#define PROT_PIN    11     // IDC 28
-#define READ_PIN    12     // IDC 30
-#define SIDE_PIN    13     // IDC 32
-#define READY_PIN   14     // IDC 34
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN A5   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN A4    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 6     // IDC 32
+#define READY_PIN 5    // IDC 34
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN 25   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN 24    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 8     // IDC 32
+#define READY_PIN 7    // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#elif defined(ARDUINO_RASPBERRY_PI_PICO)
+#define DENSITY_PIN 2 // IDC 2
+#define INDEX_PIN 3   // IDC 8
+#define SELECT_PIN 4  // IDC 12
+#define MOTOR_PIN 5   // IDC 16
+#define DIR_PIN 6     // IDC 18
+#define STEP_PIN 7    // IDC 20
+#define WRDATA_PIN 8  // IDC 22 (not used during read)
+#define WRGATE_PIN 9  // IDC 24 (not used during read)
+#define TRK0_PIN 10   // IDC 26
+#define PROT_PIN 11   // IDC 28
+#define READ_PIN 12   // IDC 30
+#define SIDE_PIN 13   // IDC 32
+#define READY_PIN 14  // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
 #else
 #error "Please set up pin definitions!"
 #endif
+
 
 Adafruit_Floppy floppy(DENSITY_PIN, INDEX_PIN, SELECT_PIN,
                        MOTOR_PIN, DIR_PIN, STEP_PIN,

--- a/examples/msd_test/msd_test.ino
+++ b/examples/msd_test/msd_test.ino
@@ -4,54 +4,60 @@
 #include <Adafruit_Floppy.h>
 #include "Adafruit_TinyUSB.h"
 
-Adafruit_USBD_MSC usb_msc;
-
-// If using SAMD51, turn on TINYUSB USB stack
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      A4    // IDC 18
-#define STEP_PIN     A5    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      6    // IDC 32
-#define READY_PIN     5    // IDC 34
-#elif defined (ARDUINO_ADAFRUIT_FEATHER_RP2040)
-#define DENSITY_PIN  A0    // IDC 2
-#define INDEX_PIN    A1    // IDC 8
-#define SELECT_PIN   A2    // IDC 12
-#define MOTOR_PIN    A3    // IDC 16
-#define DIR_PIN      24    // IDC 18
-#define STEP_PIN     25    // IDC 20
-#define WRDATA_PIN   13    // IDC 22 (not used during read)
-#define WRGATE_PIN   12    // IDC 24 (not used during read)
-#define TRK0_PIN     11    // IDC 26
-#define PROT_PIN     10    // IDC 28
-#define READ_PIN      9    // IDC 30
-#define SIDE_PIN      8    // IDC 32
-#define READY_PIN     7    // IDC 34
-#elif defined (ARDUINO_RASPBERRY_PI_PICO)
-#define DENSITY_PIN  2     // IDC 2
-#define INDEX_PIN    3     // IDC 8
-#define SELECT_PIN   4     // IDC 12
-#define MOTOR_PIN    5     // IDC 16
-#define DIR_PIN      6     // IDC 18
-#define STEP_PIN     7     // IDC 20
-#define WRDATA_PIN   8     // IDC 22 (not used during read)
-#define WRGATE_PIN   9     // IDC 24 (not used during read)
-#define TRK0_PIN    10     // IDC 26
-#define PROT_PIN    11     // IDC 28
-#define READ_PIN    12     // IDC 30
-#define SIDE_PIN    13     // IDC 32
-#define READY_PIN   14     // IDC 34
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN A5   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN A4    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 6     // IDC 32
+#define READY_PIN 5    // IDC 34
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+#define DENSITY_PIN A1 // IDC 2
+#define INDEX_PIN 25   // IDC 8
+#define SELECT_PIN A0  // IDC 12
+#define MOTOR_PIN A2   // IDC 16
+#define DIR_PIN A3     // IDC 18
+#define STEP_PIN 24    // IDC 20
+#define WRDATA_PIN 13  // IDC 22
+#define WRGATE_PIN 12  // IDC 24
+#define TRK0_PIN 10    // IDC 26
+#define PROT_PIN 11    // IDC 28
+#define READ_PIN 9     // IDC 30
+#define SIDE_PIN 8     // IDC 32
+#define READY_PIN 7    // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
+#elif defined(ARDUINO_RASPBERRY_PI_PICO)
+#define DENSITY_PIN 2 // IDC 2
+#define INDEX_PIN 3   // IDC 8
+#define SELECT_PIN 4  // IDC 12
+#define MOTOR_PIN 5   // IDC 16
+#define DIR_PIN 6     // IDC 18
+#define STEP_PIN 7    // IDC 20
+#define WRDATA_PIN 8  // IDC 22 (not used during read)
+#define WRGATE_PIN 9  // IDC 24 (not used during read)
+#define TRK0_PIN 10   // IDC 26
+#define PROT_PIN 11   // IDC 28
+#define READ_PIN 12   // IDC 30
+#define SIDE_PIN 13   // IDC 32
+#define READY_PIN 14  // IDC 34
+#ifndef USE_TINYUSB
+#error "Please set Adafruit TinyUSB under Tools > USB Stack"
+#endif
 #else
 #error "Please set up pin definitions!"
 #endif
+
+
+Adafruit_USBD_MSC usb_msc;
 
 Adafruit_Floppy floppy(DENSITY_PIN, INDEX_PIN, SELECT_PIN,
                        MOTOR_PIN, DIR_PIN, STEP_PIN,

--- a/src/Adafruit_MFM_Floppy.cpp
+++ b/src/Adafruit_MFM_Floppy.cpp
@@ -175,7 +175,7 @@ bool Adafruit_MFM_Floppy::readSector(uint32_t block, uint8_t *dst) {
 bool Adafruit_MFM_Floppy::readSectors(uint32_t block, uint8_t *dst, size_t nb) {
   // read each block one by one
   for (size_t blocknum = 0; blocknum < nb; blocknum++) {
-    if (!readBlock(block + blocknum, dst + (blocknum * MFM_BYTES_PER_SECTOR)))
+    if (!readSector(block + blocknum, dst + (blocknum * MFM_BYTES_PER_SECTOR)))
       return false;
   }
   return true;


### PR DESCRIPTION
This updates the pinout to match the "rev C" prototype featherwing.  Tested on Feather M4, but the Feather RP2040 pinout was also updated to match.

reading and writing both work with the new featherwing, and the write protect slide switch works (but fluxengine is bugged, at least at the 6 month old ref I'm using, and doesn't detect that the data wasn't written as long as it's in the correct format! This is the same if the WP tab of the drive is engaged or if the WP slide switch of the featherwing is engaged)

The standard feather pinouts were extracted to a header since repetition is bad. repetition is bad. is bad.

@ladyada 