### PR TITLE
When printing flux bins, skip "small bins"

### DIFF
--- a/examples/floppy_capture_track_test/floppy_capture_track_test.ino
+++ b/examples/floppy_capture_track_test/floppy_capture_track_test.ino
@@ -68,7 +68,10 @@ void setup() {
   while (!Serial) delay(100);
 delay(3000);
   Serial.println("its time for a nice floppy transfer!");
-  Serial.printf("Sample freqency %.1fMHz\n", floppy->getSampleFrequency() / 1e6);
+  Serial.print("Sample freqency ");
+  Serial.print(floppy.getSampleFrequency() / 1e6);
+  Serial.println("MHz");
+
   floppy.debug_serial = &Serial;
 
   if (!floppy.begin()) {

--- a/examples/floppy_capture_track_test/floppy_capture_track_test.ino
+++ b/examples/floppy_capture_track_test/floppy_capture_track_test.ino
@@ -66,8 +66,9 @@ uint32_t time_stamp = 0;
 void setup() {
   Serial.begin(115200);
   while (!Serial) delay(100);
-
+delay(3000);
   Serial.println("its time for a nice floppy transfer!");
+  Serial.printf("Sample freqency %.1fMHz\n", floppy->getSampleFrequency() / 1e6);
   floppy.debug_serial = &Serial;
 
   if (!floppy.begin()) {

--- a/examples/floppy_capture_track_test/floppy_capture_track_test.ino
+++ b/examples/floppy_capture_track_test/floppy_capture_track_test.ino
@@ -66,7 +66,7 @@ uint32_t time_stamp = 0;
 void setup() {
   Serial.begin(115200);
   while (!Serial) delay(100);
-delay(3000);
+
   Serial.println("its time for a nice floppy transfer!");
   Serial.print("Sample freqency ");
   Serial.print(floppy.getSampleFrequency() / 1e6);

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -818,7 +818,9 @@ void Adafruit_FloppyBase::print_pulses(uint8_t *pulses, uint32_t num_pulses,
 /**************************************************************************/
 void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
                                            uint8_t max_bins,
-                                           bool is_gw_format) {
+                                           bool is_gw_format,
+                                           uint32_t min_bin_size
+) {
   (void)is_gw_format;
   if (!debug_serial) {
     return;
@@ -859,12 +861,19 @@ void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
       debug_serial->println("oof we ran out of bins but we'll keep going");
   }
   // this is a very lazy way to print the bins sorted
+  bool gap=false;
   for (uint16_t pulse_w = 1; pulse_w < 512; pulse_w++) {
     for (uint8_t b = 0; b < max_bins; b++) {
       if (bins[b][0] == pulse_w) {
-        debug_serial->print(bins[b][0]);
-        debug_serial->print(": ");
-        debug_serial->println(bins[b][1]);
+        if(bins[b][1] >= min_bin_size) {
+          if(gap) debug_serial->println("-------");
+          gap = false;
+          debug_serial->print(bins[b][0]);
+          debug_serial->print(": ");
+          debug_serial->println(bins[b][1]);
+        } else {
+          gap = true;
+        }
       }
     }
   }

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -814,6 +814,7 @@ void Adafruit_FloppyBase::print_pulses(uint8_t *pulses, uint32_t num_pulses,
     @param  num_pulses The size of the pulses in the array
     @param  max_bins The maximum number of histogram bins to use (default 64)
     @param  is_gw_format Set to true if we pack long pulses with two bytes
+    @param  min_bin_size Bins with fewer samples than this are skipped, not printed
 */
 /**************************************************************************/
 void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -814,7 +814,8 @@ void Adafruit_FloppyBase::print_pulses(uint8_t *pulses, uint32_t num_pulses,
     @param  num_pulses The size of the pulses in the array
     @param  max_bins The maximum number of histogram bins to use (default 64)
     @param  is_gw_format Set to true if we pack long pulses with two bytes
-    @param  min_bin_size Bins with fewer samples than this are skipped, not printed
+    @param  min_bin_size Bins with fewer samples than this are skipped, not
+   printed
 */
 /**************************************************************************/
 void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -817,10 +817,8 @@ void Adafruit_FloppyBase::print_pulses(uint8_t *pulses, uint32_t num_pulses,
 */
 /**************************************************************************/
 void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
-                                           uint8_t max_bins,
-                                           bool is_gw_format,
-                                           uint32_t min_bin_size
-) {
+                                           uint8_t max_bins, bool is_gw_format,
+                                           uint32_t min_bin_size) {
   (void)is_gw_format;
   if (!debug_serial) {
     return;
@@ -861,12 +859,13 @@ void Adafruit_FloppyBase::print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
       debug_serial->println("oof we ran out of bins but we'll keep going");
   }
   // this is a very lazy way to print the bins sorted
-  bool gap=false;
+  bool gap = false;
   for (uint16_t pulse_w = 1; pulse_w < 512; pulse_w++) {
     for (uint8_t b = 0; b < max_bins; b++) {
       if (bins[b][0] == pulse_w) {
-        if(bins[b][1] >= min_bin_size) {
-          if(gap) debug_serial->println("-------");
+        if (bins[b][1] >= min_bin_size) {
+          if (gap)
+            debug_serial->println("-------");
           gap = false;
           debug_serial->print(bins[b][0]);
           debug_serial->print(": ");

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -139,7 +139,8 @@ public:
                    bool store_greaseweazle = false)
       __attribute__((optimize("O3")));
   void print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
-                        uint8_t max_bins = 64, bool is_gw_format = false);
+                        uint8_t max_bins = 64, bool is_gw_format = false,
+                        uint32_t min_bin_size=100);
   void print_pulses(uint8_t *pulses, uint32_t num_pulses,
                     bool is_gw_format = false);
   uint32_t getSampleFrequency(void);

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -140,7 +140,7 @@ public:
       __attribute__((optimize("O3")));
   void print_pulse_bins(uint8_t *pulses, uint32_t num_pulses,
                         uint8_t max_bins = 64, bool is_gw_format = false,
-                        uint32_t min_bin_size=100);
+                        uint32_t min_bin_size = 100);
   void print_pulses(uint8_t *pulses, uint32_t num_pulses,
                     bool is_gw_format = false);
   uint32_t getSampleFrequency(void);


### PR DESCRIPTION
This makes the "capture track" test easier to understand:
```
12:12:06.835 -> Captured 45281 flux transitions
12:12:06.835 -> -------
12:12:06.835 -> 93: 136
12:12:06.835 -> 94: 1426
12:12:06.835 -> 95: 6104
12:12:06.835 -> 96: 13427
12:12:06.835 -> 97: 11093
12:12:06.835 -> 98: 3421
12:12:06.835 -> 99: 864
12:12:06.835 -> 100: 283
12:12:06.835 -> -------
12:12:06.835 -> 140: 233
12:12:06.835 -> 141: 462
12:12:06.835 -> 142: 824
12:12:06.835 -> 143: 1062
12:12:06.835 -> 144: 1270
12:12:06.835 -> 145: 1288
12:12:06.835 -> 146: 1061
12:12:06.835 -> 147: 768
12:12:06.835 -> 148: 337
12:12:06.835 -> -------
12:12:06.835 -> 192: 112
12:12:06.835 -> 193: 125
12:12:06.835 -> 194: 134
```
so you can more easily eyeball the peaks at 96, 144, and 192 counts.