### PR TITLE
WIP: Start turning the MSD demo into something usable

### DIFF
--- a/examples/04_msd_test/04_msd_test.ino
+++ b/examples/04_msd_test/04_msd_test.ino
@@ -1,8 +1,8 @@
 // this example makes a lot of assumptions: MFM floppy which is already inserted
 // and only reading is supported - no write yet!
 
-#include <Adafruit_Floppy.h>
 #include "Adafruit_TinyUSB.h"
+#include <Adafruit_Floppy.h>
 
 #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
 #define DENSITY_PIN A1 // IDC 2
@@ -48,20 +48,8 @@
 #define READY_PIN 14  // IDC 34
 #elif defined(ARDUINO_ADAFRUIT_FLOPPSY_RP2040)
 // Yay built in pin definitions!
-#define USE_GFX (1)
-#include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
-Adafruit_ST7789 tft = Adafruit_ST7789(&SPI1, TFT_CS, TFT_DC, TFT_RESET);
-#define TFT_INIT() do { \
-  tft.init(240, 240); \
-  pinMode(TFT_BACKLIGHT, OUTPUT); \
-  digitalWrite(TFT_BACKLIGHT, 1); \
-  tft.fillScreen(0); \
-  tft.setTextSize(3); \
-  tft.setTextColor(~0, 0); \
-  tft.setCursor(3, 3); \
-  tft.println("Floppsy MSD"); \
-  Serial.println("TFTinit!"); \
-} while(0)
+// enable the display, though!
+#include "display_floppsy.h"
 #else
 #error "Please set up pin definitions!"
 #endif
@@ -70,29 +58,28 @@ Adafruit_ST7789 tft = Adafruit_ST7789(&SPI1, TFT_CS, TFT_DC, TFT_RESET);
 #error "Please set Adafruit TinyUSB under Tools > USB Stack"
 #endif
 
-#if USE_GFX
-#include "Adafruit_GFX.h"
-#define IF_GFX(...) do { __VA_ARGS__ } while(0)
-#else
-#define IF_GFX(...) ((void)0)
-#endif
-
 Adafruit_USBD_MSC usb_msc;
 
-Adafruit_Floppy floppy(DENSITY_PIN, INDEX_PIN, SELECT_PIN,
-                       MOTOR_PIN, DIR_PIN, STEP_PIN,
-                       WRDATA_PIN, WRGATE_PIN, TRK0_PIN,
-                       PROT_PIN, READ_PIN, SIDE_PIN, READY_PIN);
+Adafruit_Floppy floppy(DENSITY_PIN, INDEX_PIN, SELECT_PIN, MOTOR_PIN, DIR_PIN,
+                       STEP_PIN, WRDATA_PIN, WRGATE_PIN, TRK0_PIN, PROT_PIN,
+                       READ_PIN, SIDE_PIN, READY_PIN);
 
-// You can select IBMPC1440K or IBMPC360K (check adafruit_floppy_disk_t options!)
+// You can select IBMPC1440K or IBMPC360K (check adafruit_floppy_disk_t
+// options!)
 auto FLOPPY_TYPE = AUTODETECT;
 Adafruit_MFM_Floppy mfm_floppy(&floppy, FLOPPY_TYPE);
 
+// To make a display on another board, check out "display_floppsy.h"; adapt it
+// to your board & include it
+#if defined(HAVE_DISPLAY)
+#include "display_common.h"
+#else
+#include "display_none.h"
+#endif
 
 constexpr size_t SECTOR_SIZE = 512UL;
 
 void setup() {
-  TFT_INIT();
   Serial.begin(115200);
 
 #if defined(FLOPPY_DIRECTION_PIN)
@@ -101,19 +88,22 @@ void setup() {
 #endif
 
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
-  // Manual begin() is required on core without built-in support for TinyUSB such as
+  // Manual begin() is required on core without built-in support for TinyUSB
+  // such as
   // - mbed rp2040
   TinyUSB_Device_Init(0);
 #endif
 
-  // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
+  // Set disk vendor id, product id and revision with string up to 8, 16, 4
+  // characters respectively
   usb_msc.setID("Adafruit", "Floppy Mass Storage", "1.0");
 
   // Set disk size
   usb_msc.setCapacity(0, SECTOR_SIZE);
   // Set callbacks
   usb_msc.setReadyCallback(0, msc_ready_callback);
-  usb_msc.setReadWriteCallback(msc_read_callback, msc_write_callback, msc_flush_callback);
+  usb_msc.setReadWriteCallback(msc_read_callback, msc_write_callback,
+                               msc_flush_callback);
 
   // floppy.debug_serial = &Serial;
   // Set Lun ready
@@ -123,166 +113,93 @@ void setup() {
 
   Serial.println("serial Ready!");
 
+  init_display();
+
   floppy.begin();
-  if (! mfm_floppy.begin()) {
+  attachInterrupt(digitalPinToInterrupt(INDEX_PIN), count_index, FALLING);
+  if (!mfm_floppy.begin()) {
     Serial.println("Failed to spin up motor & find index pulse");
     mfm_floppy.removed();
   }
-
-  IF_GFX(tft.fillScreen(0););
 }
 
-uint32_t index_time, last_update_time;
-bool index_ui_state, index_ui_state_delayed;
-volatile bool update_queued;
+volatile uint32_t flush_time;
 
-#if USE_GFX
-const char spinner[4] = {' ', '.', 'o', 'O'};
-size_t i_spin;
-
-void update_display() {
-  noInterrupts();
-  auto trk0 = floppy.get_track0_sense();
-  auto wp = floppy.get_write_protect();
-  auto ind = digitalRead(INDEX_PIN);
-  auto rdy = digitalRead(READY_PIN);
-  auto dirty = mfm_floppy.dirty();
-  int x = 3;
-  int y = 3;
-  tft.setCursor(x, y);
-  tft.printf("%s %s %s",
-      trk0 ? "TRK0" : "    ",
-      wp ? "R/O" : "   ",
-      rdy ? "RDY" : index_ui_state ? "IDX" : "   "
-  );
-
-  y += 24;
-  tft.setCursor(x, y);
-  if (mfm_floppy.sectorCount() == 0) {
-      tft.printf("NO MEDIA ");
-      y += 24;
-      tft.setCursor(x, y);
-      tft.printf("         ");
-  } else {
-      tft.printf("%4d KiB ", mfm_floppy.sectorCount()/2);
-      y += 24;
-      tft.setCursor(x, y);
-      if (floppy.track() == -1) {
-          tft.printf("T:?? S:? ");
-      } else {
-          tft.printf("T:%02d S:%d ",
-            floppy.track(),
-            floppy.get_side()
-          );
-      }
-  }
-  y += 24;
-  tft.setCursor(x, y);
-  tft.printf("%s %c",
-    dirty ? "dirty" : "     ", spinner[i_spin++ % std::size(spinner)]);
-  interrupts();
-}
-void maybe_update_display(uint32_t now) {
-    noInterrupts();
-    auto do_update = update_queued || (now - last_update_time) > 500;
-    update_queued = false;
-    interrupts();
-
-    if (do_update) {
-        update_display();
-        last_update_time = now;
-    } else {
-        yield();
-    }
-}
-
-void queue_update_display() {
-}
-
-#else
-void maybe_update_display(uint32_t now) {
-}
-
-void queue_update_display() {}
-
-#endif
+volatile uint32_t index_count;
+void count_index() { index_count += 1; }
 
 bool index_delayed, ready_delayed;
+uint32_t old_index_count;
 void loop() {
   uint32_t now = millis();
   bool index = !digitalRead(INDEX_PIN);
   bool ready = digitalRead(READY_PIN);
 
+  noInterrupts();
+  auto new_index_count = index_count;
+  interrupts();
+
+  if (mfm_floppy.dirty() && now > flush_time) {
+    noInterrupts();
+    mfm_floppy.syncDevice();
+    interrupts();
+  }
+
   // ready pin fell: media ejected
   if (!ready && ready_delayed) {
     Serial.println("removed");
     mfm_floppy.removed();
-    queue_update_display();
   }
-  if (index && !index_delayed) {
-    index_time = now;
+  if (new_index_count != old_index_count) {
     if (mfm_floppy.sectorCount() == 0) {
-        Serial.println("inserted");
-        mfm_floppy.inserted(FLOPPY_TYPE);
-        queue_update_display();
+      Serial.println("inserted");
+      mfm_floppy.inserted(FLOPPY_TYPE);
     }
   }
 
-  index_ui_state = (now - index_time) < 400;
-  if (index_ui_state != index_ui_state_delayed) {
-        queue_update_display();
-  }
-
-  index_ui_state_delayed = index_ui_state;
-  index_delayed = index;
+  maybe_update_display(false, new_index_count != old_index_count);
   ready_delayed = ready;
-
-  maybe_update_display(now);
+  old_index_count = new_index_count;
 }
 
 // Callback invoked when received READ10 command.
 // Copy disk's data to buffer (up to bufsize) and
 // return number of copied bytes (must be multiple of block size)
-int32_t msc_read_callback (uint32_t lba, void* buffer, uint32_t bufsize)
-{
-  //Serial.printf("read call back block %d size %d\r\n", lba, bufsize);
-  auto result = mfm_floppy.readSectors(lba, reinterpret_cast<uint8_t*>(buffer), bufsize / MFM_BYTES_PER_SECTOR);
-  queue_update_display();
+int32_t msc_read_callback(uint32_t lba, void *buffer, uint32_t bufsize) {
+  // Serial.printf("read call back block %d size %d\r\n", lba, bufsize);
+  auto result = mfm_floppy.readSectors(lba, reinterpret_cast<uint8_t *>(buffer),
+                                       bufsize / MFM_BYTES_PER_SECTOR);
   return result ? bufsize : -1;
 }
 
 // Callback invoked when received WRITE10 command.
 // Process data in buffer to disk's storage and
 // return number of written bytes (must be multiple of block size)
-int32_t msc_write_callback (uint32_t lba, uint8_t* buffer, uint32_t bufsize)
-{
-  //Serial.printf("write call back block %d size %d\r\n", lba, bufsize);
-  auto sectors =  bufsize / MFM_BYTES_PER_SECTOR;
+int32_t msc_write_callback(uint32_t lba, uint8_t *buffer, uint32_t bufsize) {
+  // Serial.printf("write call back block %d size %d\r\n", lba, bufsize);
+  auto sectors = bufsize / MFM_BYTES_PER_SECTOR;
   auto result = mfm_floppy.writeSectors(lba, buffer, sectors);
   if (result) {
+    flush_time = millis() + 200;
     if (lba == 0 || (lba + sectors) == mfm_floppy.sectorCount()) {
       // If writing the first or last sector,
       mfm_floppy.syncDevice();
     }
   }
-  queue_update_display();
   return result ? bufsize : -1;
 }
 
-// Callback invoked when WRITE10 command is completed (status received and accepted by host).
-// used to flush any pending cache.
-void msc_flush_callback (void)
-{
+// Callback invoked when WRITE10 command is completed (status received and
+// accepted by host). used to flush any pending cache.
+void msc_flush_callback(void) {
   Serial.print("flush\r\n");
   mfm_floppy.syncDevice();
-  queue_update_display();
   // nothing to do
 }
 
-bool msc_ready_callback (void)
-{
-//Serial.printf("ready callback -> %d\r\n", mfm_floppy.sectorCount());
-auto sectors = mfm_floppy.sectorCount();
+bool msc_ready_callback(void) {
+  // Serial.printf("ready callback -> %d\r\n", mfm_floppy.sectorCount());
+  auto sectors = mfm_floppy.sectorCount();
   usb_msc.setCapacity(sectors, SECTOR_SIZE);
   return sectors != 0;
 }

--- a/examples/04_msd_test/04_msd_test.ino
+++ b/examples/04_msd_test/04_msd_test.ino
@@ -102,6 +102,7 @@ void setup() {
   usb_msc.setCapacity(0, SECTOR_SIZE);
   // Set callbacks
   usb_msc.setReadyCallback(0, msc_ready_callback);
+  usb_msc.setWritableCallback(0, msc_writable_callback);
   usb_msc.setReadWriteCallback(msc_read_callback, msc_write_callback,
                                msc_flush_callback);
 
@@ -203,3 +204,5 @@ bool msc_ready_callback(void) {
   usb_msc.setCapacity(sectors, SECTOR_SIZE);
   return sectors != 0;
 }
+
+bool msc_writable_callback(void) { return !floppy.get_write_protect(); }

--- a/examples/04_msd_test/display_common.h
+++ b/examples/04_msd_test/display_common.h
@@ -1,0 +1,33 @@
+#pragma once
+
+bool ever_refreshed;
+
+void update_display(bool force_refresh);
+
+bool operator!=(const display_state &a, const display_state &b) {
+  return a.capacity_kib != b.capacity_kib || a.trk0 != b.trk0 || a.wp != b.wp ||
+         a.rdy != b.rdy || a.dirty != b.dirty || a.trk != b.trk ||
+         a.side != b.side;
+}
+
+void maybe_update_display(bool force_refresh, bool tick) {
+  noInterrupts();
+  new_state = display_state{
+      mfm_floppy.sectorCount() / 2,
+      floppy.get_track0_sense(),
+      floppy.get_write_protect(),
+      !!digitalRead(READY_PIN),
+      mfm_floppy.dirty(),
+      floppy.track(),
+      floppy.get_side(),
+  };
+  interrupts();
+
+  force_refresh = force_refresh || !ever_refreshed;
+  if (force_refresh || (old_state != new_state) || tick) {
+    Serial.printf("P %d\n", new_state.trk);
+    update_display(force_refresh);
+    old_state = new_state;
+    ever_refreshed = true;
+  }
+}

--- a/examples/04_msd_test/display_floppsy.h
+++ b/examples/04_msd_test/display_floppsy.h
@@ -1,0 +1,162 @@
+#pragma once
+#include "display_state.h"
+#include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
+#define HAVE_DISPLAY (1)
+
+Adafruit_ST7789 display = Adafruit_ST7789(&SPI1, TFT_CS, TFT_DC, TFT_RESET);
+
+enum { SZ = 3 };
+
+static void setCursor(int x, int y) {
+  display.setCursor(x * SZ * 6 + 12, y * SZ * 8 + 12);
+}
+
+void init_display() {
+  display.init(240, 240);
+  display.fillScreen(0);
+  pinMode(TFT_BACKLIGHT, OUTPUT);
+  digitalWrite(TFT_BACKLIGHT, 1);
+  display.setTextSize(SZ);
+}
+
+/*!
+  @brief   Convert hue, saturation and value into a packed 16-bit RGB color
+           that can be passed to TFT
+  @param   H  The Hue ranging from 0 to 359
+  @param   S  Saturation, 8-bit value, 0 (min or pure grayscale) to 100
+                (max or pure hue)
+  @param   V  Value (brightness), 8-bit value, 0 (min / black / off) to
+                100 (max or full brightness)
+  @return  Packed 16-bit 5-6-5 RGB. Result is linearly but not perceptually
+           correct for LEDs. Intended for TFT use only.
+*/
+// https://gist.github.com/kuathadianto/200148f53616cbd226d993b400214a7f
+uint16_t ColorHSV565(int16_t H, uint8_t S = 100, uint8_t V = 100) {
+  float C = S * V / 10000.0f;
+  float X = C * (1 - abs(fmod(H / 60.0f, 2) - 1));
+  float m = (V / 100.0f) - C;
+  float Rs, Gs, Bs;
+
+  if (H >= 0 && H < 60) {
+    Rs = C;
+    Gs = X;
+    Bs = 0;
+  } else if (H >= 60 && H < 120) {
+    Rs = X;
+    Gs = C;
+    Bs = 0;
+  } else if (H >= 120 && H < 180) {
+    Rs = 0;
+    Gs = C;
+    Bs = X;
+  } else if (H >= 180 && H < 240) {
+    Rs = 0;
+    Gs = X;
+    Bs = C;
+  } else if (H >= 240 && H < 300) {
+    Rs = X;
+    Gs = 0;
+    Bs = C;
+  } else {
+    Rs = C;
+    Gs = 0;
+    Bs = X;
+  }
+
+  uint8_t red = (Rs + m) * 255;
+  uint8_t green = (Gs + m) * 255;
+  uint8_t blue = (Bs + m) * 255;
+  return display.color565(red, green, blue);
+}
+
+void update_display(bool force_refresh) {
+  int x = 3;
+  int y = 3;
+
+  Serial.printf("%u\n", millis());
+  if (force_refresh) {
+    display.fillScreen(0);
+  }
+
+  static int phase = 0;
+  phase = phase + 53;
+
+  // Top row
+  int row = 0;
+  setCursor(2, 0);
+  for (int i = 0; i < 7; i++) {
+    display.setTextColor(ColorHSV565((i * 360 / 7 + phase) % 360), 0);
+    display.print("FLOPPSY"[i]);
+  }
+
+  // Media row
+  row += 2;
+  if (force_refresh || new_state.capacity_kib != old_state.capacity_kib) {
+    setCursor(0, row);
+    Serial.printf("row 2 dirty capacity_kib=%d\n", new_state.capacity_kib);
+    if (new_state.capacity_kib) {
+      display.setTextColor(ST77XX_WHITE, 0);
+      display.printf("%d KiB   ", new_state.capacity_kib);
+    } else {
+      display.setTextColor(ST77XX_MAGENTA, 0);
+      display.printf("NO MEDIA");
+    }
+  }
+
+  // Head position row
+  row += 3;
+  printf("new trk=%d old_trk=%d\n", new_state.trk, old_state.trk);
+  if (force_refresh || new_state.trk != old_state.trk) {
+    if (force_refresh) {
+      setCursor(0, row);
+      display.setTextColor(ST77XX_WHITE, 0);
+      display.print("T:");
+    }
+    setCursor(2, row);
+    if (new_state.trk < 0 || new_state.trk > 99) {
+      display.setTextColor(ST77XX_RED, 0);
+      display.print("??");
+    } else {
+      display.setTextColor(ST77XX_GREEN, 0);
+      display.printf("%02d", new_state.trk);
+    }
+  }
+  if (force_refresh || new_state.side != old_state.side) {
+    display.setTextColor(ST77XX_WHITE, 0);
+    if (force_refresh) {
+      setCursor(5, row);
+      display.print("S:");
+    }
+    setCursor(7, row);
+    display.printf("%d", new_state.side);
+  }
+
+  // Dirty row
+  row += 2;
+  if (force_refresh || new_state.dirty != old_state.dirty) {
+    display.setTextColor(ST77XX_MAGENTA, 0);
+    display.setCursor(0, 5);
+    display.print(new_state.dirty ? "dirty" : "     ");
+  }
+
+  // Sense row
+  row += 1;
+  if (force_refresh || new_state.trk0 != old_state.trk0) {
+    setCursor(0, row);
+    display.setTextColor(ST77XX_GREEN, 0);
+    display.print(new_state.trk0 ? "TRK0" : "    ");
+  };
+
+  Serial.printf("wp=%d\n", new_state.wp);
+  if (force_refresh || new_state.wp != old_state.wp) {
+    setCursor(5, row);
+    display.setTextColor(ST77XX_MAGENTA, 0);
+    display.print(new_state.wp ? "R/O" : "   ");
+  };
+
+  if (force_refresh || new_state.rdy != old_state.rdy) {
+    setCursor(9, row);
+    display.setTextColor(ST77XX_CYAN, 0);
+    display.print(new_state.rdy ? "RDY" : "   ");
+  };
+}

--- a/examples/04_msd_test/display_none.h
+++ b/examples/04_msd_test/display_none.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void init_display() {}
+void maybe_update_display(bool, bool) {}

--- a/examples/04_msd_test/display_state.h
+++ b/examples/04_msd_test/display_state.h
@@ -1,0 +1,9 @@
+#pragma once
+
+struct display_state {
+  size_t capacity_kib;
+  bool trk0, wp, rdy, dirty;
+  int8_t trk, side;
+};
+
+display_state old_state, new_state;

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -636,7 +636,7 @@ void loop() {
     switch (pin) {
       case GW_CMD_GETPIN_TRACK0:
         reply_buffer[i++] = GW_ACK_OK;
-        reply_buffer[i++] = floppy->get_track0_sense();
+        reply_buffer[i++] = !floppy->get_track0_sense();
         break;
 
       default:

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -301,6 +301,7 @@ bool Adafruit_Floppy::spin_motor(bool motor_on) {
       timedout = true; // its been a second
       break;
     }
+    yield();
   }
 
   if (timedout) {
@@ -567,13 +568,15 @@ size_t Adafruit_FloppyBase::capture_track(volatile uint8_t *pulses,
                                           size_t max_pulses,
                                           int32_t *falling_index_offset,
                                           bool store_greaseweazle,
-                                          uint32_t capture_ms) {
+                                          uint32_t capture_ms,
+                                          uint32_t index_wait_ms) {
   memset((void *)pulses, 0, max_pulses); // zero zem out
 
 #if defined(ARDUINO_ARCH_RP2040)
   return rp2040_flux_capture(_indexpin, _rddatapin, pulses, pulses + max_pulses,
                              falling_index_offset, store_greaseweazle,
-                             capture_ms * (getSampleFrequency() / 1000));
+                             capture_ms * (getSampleFrequency() / 1000),
+                             index_wait_ms);
 #elif defined(__SAMD51__)
   noInterrupts();
   wait_for_index_pulse_low();

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -568,6 +568,8 @@ uint32_t Adafruit_FloppyBase::getSampleFrequency(void) {
     @param  capture_ms If not zero, we will capture at least one revolution and
    extra time will be determined by this variable. e.g. 250ms means one
    revolution plus about 50 ms post-index
+    @param  index_wait_ms If not zero, wait at most this many ms for an index pulse
+   to arrive
     @return Number of pulses we actually captured
 */
 /**************************************************************************/

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -568,8 +568,8 @@ uint32_t Adafruit_FloppyBase::getSampleFrequency(void) {
     @param  capture_ms If not zero, we will capture at least one revolution and
    extra time will be determined by this variable. e.g. 250ms means one
    revolution plus about 50 ms post-index
-    @param  index_wait_ms If not zero, wait at most this many ms for an index pulse
-   to arrive
+    @param  index_wait_ms If not zero, wait at most this many ms for an index
+   pulse to arrive
     @return Number of pulses we actually captured
 */
 /**************************************************************************/

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -571,12 +571,9 @@ uint32_t Adafruit_FloppyBase::getSampleFrequency(void) {
     @return Number of pulses we actually captured
 */
 /**************************************************************************/
-size_t Adafruit_FloppyBase::capture_track(volatile uint8_t *pulses,
-                                          size_t max_pulses,
-                                          int32_t *falling_index_offset,
-                                          bool store_greaseweazle,
-                                          uint32_t capture_ms,
-                                          uint32_t index_wait_ms) {
+size_t Adafruit_FloppyBase::capture_track(
+    volatile uint8_t *pulses, size_t max_pulses, int32_t *falling_index_offset,
+    bool store_greaseweazle, uint32_t capture_ms, uint32_t index_wait_ms) {
   memset((void *)pulses, 0, max_pulses); // zero zem out
 
 #if defined(ARDUINO_ARCH_RP2040)

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -428,6 +428,13 @@ bool Adafruit_Floppy::get_write_protect(void) {
   return !digitalRead(_protectpin);
 }
 
+bool Adafruit_Floppy::get_ready_sense(void) {
+  if (_readypin == 0) {
+    return true;
+  }
+  return !digitalRead(_readypin);
+}
+
 bool Adafruit_Floppy::get_track0_sense(void) {
   if (_track0pin == 0) {
     return track() != 0;

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -429,9 +429,9 @@ bool Adafruit_Floppy::get_write_protect(void) {
 
 bool Adafruit_Floppy::get_track0_sense(void) {
   if (_track0pin == 0) {
-    return track() == 0;
+    return track() != 0;
   }
-  return digitalRead(_track0pin);
+  return !digitalRead(_track0pin);
 }
 
 bool Adafruit_Floppy::set_density(bool high_density) {

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -322,8 +322,6 @@ public:
   bool begin(void);
   void end(void);
 
-  adafruit_floppy_disk_t format() const { return _format; }
-
   uint32_t size(void) const;
   int32_t readTrack(uint8_t track, bool head);
 
@@ -334,9 +332,15 @@ public:
        @returns The number of tracks per side */
   uint8_t tracks_per_side(void) const { return _tracks_per_side; }
 
+  /**! @brief Check if there is data to be written to the current track
+       @returns True if data needs to be written out */
   bool dirty() const { return _dirty; }
 
+  /**! @brief Call when the media has been removed */
   void removed();
+  /**! @brief Call when media has been inserted
+       @param format The hard coded format or AUTODETECT to try several common formats
+       @returns True if media is hard coded or if the media was detected by autodetect */
   bool inserted(adafruit_floppy_disk_t format);
 
   //------------- SdFat v2 FsBlockDeviceInterface API -------------//

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -157,7 +157,11 @@ public:
                     bool is_gw_format = false);
   uint32_t getSampleFrequency(void);
 
+#if defined(LED_BUILTIN)
   int8_t led_pin = LED_BUILTIN; ///< Debug LED output for tracing
+#else
+  int8_t led_pin = -1; ///< Debug LED output for tracing
+#endif
 
   uint16_t select_delay_us = 10;  ///< delay after drive select (usecs)
   uint16_t step_delay_us = 10000; ///< delay between head steps (usecs)

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -339,8 +339,10 @@ public:
   /**! @brief Call when the media has been removed */
   void removed();
   /**! @brief Call when media has been inserted
-       @param format The hard coded format or AUTODETECT to try several common formats
-       @returns True if media is hard coded or if the media was detected by autodetect */
+       @param format The hard coded format or AUTODETECT to try several common
+     formats
+       @returns True if media is hard coded or if the media was detected by
+     autodetect */
   bool inserted(adafruit_floppy_disk_t format);
 
   //------------- SdFat v2 FsBlockDeviceInterface API -------------//

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -141,7 +141,6 @@ public:
   /**************************************************************************/
   virtual bool get_ready_sense() = 0;
 
-
   /**************************************************************************/
   /*!
       @brief  Set the density for flux reading and writing
@@ -327,7 +326,6 @@ public:
 
   uint32_t size(void) const;
   int32_t readTrack(uint8_t track, bool head);
-
 
   /**! @brief The expected number of sectors per track in this format
        @returns The number of sectors per track */

--- a/src/Adafruit_MFM_Floppy.cpp
+++ b/src/Adafruit_MFM_Floppy.cpp
@@ -28,7 +28,7 @@ static const adafruit_floppy_format_info_t _format_info[] = {
 };
 /// @endcond
 
-static_assert(std::size(_format_info) == AUTODETECT);
+static_assert(sizeof(_format_info)/sizeof(_format_info[0]) == AUTODETECT);
 
 /**************************************************************************/
 /*!

--- a/src/Adafruit_MFM_Floppy.cpp
+++ b/src/Adafruit_MFM_Floppy.cpp
@@ -1,5 +1,6 @@
 #include <Adafruit_Floppy.h>
 
+/// @cond false
 static const uint16_t flux_rates[] = {2000, 1000, 867, 1667};
 
 struct adafruit_floppy_format_info_t {
@@ -25,6 +26,7 @@ static const adafruit_floppy_format_info_t _format_info[] = {
     /* IBMPC1440K_360RPM */
     {80, 18, 867, 167},
 };
+/// @endcond
 
 static_assert(std::size(_format_info) == AUTODETECT);
 

--- a/src/Adafruit_MFM_Floppy.cpp
+++ b/src/Adafruit_MFM_Floppy.cpp
@@ -28,7 +28,7 @@ static const adafruit_floppy_format_info_t _format_info[] = {
 };
 /// @endcond
 
-static_assert(sizeof(_format_info)/sizeof(_format_info[0]) == AUTODETECT);
+static_assert(sizeof(_format_info) / sizeof(_format_info[0]) == AUTODETECT);
 
 /**************************************************************************/
 /*!

--- a/src/arch_rp2.cpp
+++ b/src/arch_rp2.cpp
@@ -186,8 +186,7 @@ static uint8_t *capture_foreground(int index_pin, uint8_t *start, uint8_t *end,
                                    int32_t *falling_index_offset,
                                    bool store_greaseweazle,
                                    uint32_t capture_counts,
-                                   uint32_t max_wait_time
-                                   ) {
+                                   uint32_t max_wait_time) {
   uint8_t *ptr = start;
   if (falling_index_offset) {
     *falling_index_offset = -1;
@@ -197,16 +196,16 @@ static uint8_t *capture_foreground(int index_pin, uint8_t *start, uint8_t *end,
   // wait for a falling edge of index pin, then enable the capture peripheral
   uint32_t start_time = millis();
   while (!gpio_get(index_pin)) { /* NOTHING */
-      if (millis() - start_time > max_wait_time) {
-            disable_capture();
-            return ptr;
-      }
+    if (millis() - start_time > max_wait_time) {
+      disable_capture();
+      return ptr;
+    }
   }
   while (gpio_get(index_pin)) { /* NOTHING */
-      if (millis() - start_time > max_wait_time) {
-            disable_capture();
-            return ptr;
-      }
+    if (millis() - start_time > max_wait_time) {
+      disable_capture();
+      return ptr;
+    }
   }
 
   uint32_t total_counts = 0;
@@ -381,7 +380,7 @@ uint32_t rp2040_flux_capture(int index_pin, int rdpin, volatile uint8_t *pulses,
   if (!init_capture(index_pin, rdpin)) {
     return 0;
   }
-  
+
   auto result =
       capture_foreground(index_pin, (uint8_t *)pulses, (uint8_t *)pulse_end,
                          falling_index_offset, store_greaseweazle,

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -1,4 +1,8 @@
 #pragma once
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #if defined(ARDUINO_ARCH_RP2040)
 #define read_index_fast() gpio_get(_indexpin)
 #define read_data() gpio_get(_rddatapin)
@@ -10,8 +14,12 @@
 extern uint32_t
 rp2040_flux_capture(int indexpin, int rdpin, volatile uint8_t *pulses,
                     volatile uint8_t *end, int32_t *falling_index_offset,
-                    bool store_greaseweazle, uint32_t capture_counts);
+                    bool store_greaseweazle, uint32_t capture_counts, uint32_t index_wait_ms);
 extern bool rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
                               uint8_t *pulses, uint8_t *pulse_end,
                               bool store_greaseweazel, bool is_apple2);
+#endif
+
+#if defined(__cplusplus)
+}
 #endif

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -14,7 +14,8 @@ extern "C" {
 extern uint32_t
 rp2040_flux_capture(int indexpin, int rdpin, volatile uint8_t *pulses,
                     volatile uint8_t *end, int32_t *falling_index_offset,
-                    bool store_greaseweazle, uint32_t capture_counts, uint32_t index_wait_ms);
+                    bool store_greaseweazle, uint32_t capture_counts,
+                    uint32_t index_wait_ms);
 extern bool rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
                               uint8_t *pulses, uint8_t *pulse_end,
                               bool store_greaseweazel, bool is_apple2);


### PR DESCRIPTION
* Use the TFT on the Floppsy to show some I/O states, track & side, a "dirty" indicator, and a throbber
* add a timeout to flux capturing waiting for the index pulse
* handle disk removal/insertion about as well as I can
* make a step towards autodetection (just defining an enum value for it)
* allow re-writing a full track even if it had errors when read
  * this still has problems related to rewriting "sector zero", because
    it is flushed immediately right now
  * this is basically a low level format
