### PR TITLE
Floppsy: Changes for apple2 interface & output enable

### DIFF
--- a/examples/01_floppy_capture_track_test/01_floppy_capture_track_test.ino
+++ b/examples/01_floppy_capture_track_test/01_floppy_capture_track_test.ino
@@ -73,6 +73,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
   Serial.println("its time for a nice floppy transfer!");
   Serial.print("Sample freqency ");

--- a/examples/02_mfm_test/02_mfm_test.ino
+++ b/examples/02_mfm_test/02_mfm_test.ino
@@ -75,6 +75,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
   delay(500); // wait for serial to open
   Serial.println("its time for a nice floppy transfer!");

--- a/examples/03_fat_test/03_fat_test.ino
+++ b/examples/03_fat_test/03_fat_test.ino
@@ -91,6 +91,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
   Serial.println("Floppy FAT directory listing demo");
 

--- a/examples/04_msd_test/04_msd_test.ino
+++ b/examples/04_msd_test/04_msd_test.ino
@@ -86,6 +86,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB

--- a/examples/05_mfm_write_test/05_mfm_write_test.ino
+++ b/examples/05_mfm_write_test/05_mfm_write_test.ino
@@ -75,6 +75,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
   delay(500); // wait for serial to open
   Serial.println("its time for a nice floppy transfer!");

--- a/examples/99_floppy_write_test/99_floppy_write_test.ino
+++ b/examples/99_floppy_write_test/99_floppy_write_test.ino
@@ -77,6 +77,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
   Serial.println("its time for a nice floppy transfer!");
   floppy.debug_serial = &Serial;

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -169,6 +169,10 @@ void setup() {
   pinMode(FLOPPY_DIRECTION_PIN, OUTPUT);
   digitalWrite(FLOPPY_DIRECTION_PIN, HIGH);
 #endif
+#if defined(FLOPPY_ENABLE_PIN)
+  pinMode(FLOPPY_ENABLE_PIN, OUTPUT);
+  digitalWrite(FLOPPY_ENABLE_PIN, LOW); // do second after setting direction
+#endif
 
   delay(100);
   

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -113,7 +113,8 @@ uint8_t cmd_buff_idx = 0;
 #define GW_CMD_SETBUSTYPE 14
 #define GW_CMD_SETBUSTYPE_IBM 1
 #define GW_CMD_SETBUSTYPE_SHUGART 2
-#define GW_CMD_SETBUSTYPE_APPLE2 3
+#define GW_CMD_SETBUSTYPE_APPLE2_GW 4
+#define GW_CMD_SETBUSTYPE_APPLE2_FLUXENGINE 3
 #define GW_CMD_SETPIN    15
 #define GW_CMD_SETPIN_DENSITY 2
 #define GW_CMD_RESET     16
@@ -146,7 +147,8 @@ bool setbustype(int bustype) {
       break;
 #endif
 #ifdef APPLE2_RDDATA_PIN
-    case GW_CMD_SETBUSTYPE_APPLE2:
+    case GW_CMD_SETBUSTYPE_APPLE2_GW:
+    case GW_CMD_SETBUSTYPE_APPLE2_FLUXENGINE:
       floppy = &apple2floppy;
       apple2floppy.step_mode(Adafruit_Apple2Floppy::STEP_MODE_QUARTER);
       break;

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -79,8 +79,7 @@ Adafruit_Apple2Floppy apple2floppy(APPLE2_INDEX_PIN, APPLE2_ENABLE_PIN,
                                    APPLE2_PHASE1_PIN, APPLE2_PHASE2_PIN, APPLE2_PHASE3_PIN, APPLE2_PHASE4_PIN,
                                    APPLE2_WRDATA_PIN, APPLE2_WRGATE_PIN, APPLE2_PROTECT_PIN, APPLE2_RDDATA_PIN);
 #else
-// #pragma message "This firmware will not support Apple ][ drives"
-#error "This firmware will not support Apple ][ drives"
+#pragma message "This firmware will not support Apple ][ drives"
 #endif
 
 Adafruit_FloppyBase *floppy;

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -79,7 +79,8 @@ Adafruit_Apple2Floppy apple2floppy(APPLE2_INDEX_PIN, APPLE2_ENABLE_PIN,
                                    APPLE2_PHASE1_PIN, APPLE2_PHASE2_PIN, APPLE2_PHASE3_PIN, APPLE2_PHASE4_PIN,
                                    APPLE2_WRDATA_PIN, APPLE2_WRGATE_PIN, APPLE2_PROTECT_PIN, APPLE2_RDDATA_PIN);
 #else
-#pragma message "This firmware will not support Apple ][ drives"
+// #pragma message "This firmware will not support Apple ][ drives"
+#error "This firmware will not support Apple ][ drives"
 #endif
 
 Adafruit_FloppyBase *floppy;
@@ -236,10 +237,11 @@ void loop() {
 
   int i = 0;
   uint8_t cmd = cmd_buffer[0];
+  uint8_t len = cmd_buffer[1];
   memset(reply_buffer, 0, sizeof(reply_buffer));
   reply_buffer[i++] = cmd;  // echo back the cmd itself
 
-  Serial1.printf("Got command 0x%02x of length %d\n\r", cmd, cmd_buffer[1]);
+  Serial1.printf("Got command 0x%02x of length %d\n\r", cmd, len);
 
 
   if (cmd == GW_CMD_GETINFO) {
@@ -334,7 +336,11 @@ void loop() {
   else if (cmd == GW_CMD_SEEK) {
     if (!floppy) goto needfloppy;
 
-    uint8_t track = cmd_buffer[2];
+    int track = cmd_buffer[2];
+    if (len > 3) {
+        track |= cmd_buffer[3] << 8;
+    }
+
     Serial1.printf("Seek track %d\n\r", track);
     bool r = floppy->goto_track(track);
     if (r) {

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -263,7 +263,7 @@ void Adafruit_Floppy::select(bool selected) {
     @note If _sidepin is no pin, then only head 0 can be selected
 */
 /**************************************************************************/
-bool Adafruit_Floppy::side(uint8_t head) {
+bool Adafruit_Floppy::side(int head) {
   if (head != 0 && head != 1) {
     return false;
   }
@@ -321,7 +321,7 @@ bool Adafruit_Floppy::spin_motor(bool motor_on) {
     @return True If we were able to get to the track location
 */
 /**************************************************************************/
-bool Adafruit_Floppy::goto_track(uint8_t track_num) {
+bool Adafruit_Floppy::goto_track(int track_num) {
   // track 0 is a very special case because its the only one we actually know we
   // got to. if we dont know where we are, or we're going to track zero, step
   // back till we get there.
@@ -417,9 +417,9 @@ void Adafruit_Floppy::step(bool dir, uint8_t times) {
     @return The cached track location
 */
 /**************************************************************************/
-int8_t Adafruit_Floppy::track(void) { return _track; }
+int Adafruit_Floppy::track(void) { return _track; }
 
-int8_t Adafruit_Floppy::get_side(void) { return _side; }
+int Adafruit_Floppy::get_side(void) { return _side; }
 
 bool Adafruit_Floppy::get_write_protect(void) {
   if (_protectpin == -1) {
@@ -1079,7 +1079,7 @@ enum {
     @return True If we were able to get to the track location
 */
 /**************************************************************************/
-bool Adafruit_Apple2Floppy::goto_track(uint8_t track_num) {
+bool Adafruit_Apple2Floppy::goto_track(int track_num) {
   if (_quartertrack == -1) {
     _quartertrack = 160;
     goto_quartertrack(0);
@@ -1152,7 +1152,7 @@ void Adafruit_Apple2Floppy::_step(int direction, int count) {
     @note Apple II floppy drives only have a single side
 */
 /**************************************************************************/
-bool Adafruit_Apple2Floppy::side(uint8_t head) { return head == 0; }
+bool Adafruit_Apple2Floppy::side(int head) { return head == 0; }
 
 /**************************************************************************/
 /*!
@@ -1161,7 +1161,7 @@ bool Adafruit_Apple2Floppy::side(uint8_t head) { return head == 0; }
     @note Partial tracks are rounded, with quarter tracks always rounded down.
 */
 /**************************************************************************/
-int8_t Adafruit_Apple2Floppy::track(void) {
+int Adafruit_Apple2Floppy::track(void) {
   if (_quartertrack == -1) {
     return -1;
   }
@@ -1239,7 +1239,7 @@ bool Adafruit_Apple2Floppy::get_track0_sense(void) { return track() == 0; }
     @note Returns -1 if the position is unknown
 */
 /**************************************************************************/
-int8_t Adafruit_Apple2Floppy::quartertrack() { return _quartertrack; }
+int Adafruit_Apple2Floppy::quartertrack() { return _quartertrack; }
 
 /**************************************************************************/
 /*!

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -90,7 +90,7 @@ public:
       @return True If we were able to get to the track location
   */
   /**************************************************************************/
-  virtual bool goto_track(uint8_t track_num) = 0;
+  virtual bool goto_track(int track_num) = 0;
   /**************************************************************************/
   /*!
       @brief Which head/side to read from
@@ -98,14 +98,14 @@ public:
       @return true if the head exists, false otherwise
   */
   /**************************************************************************/
-  virtual bool side(uint8_t head) = 0;
+  virtual bool side(int head) = 0;
   /**************************************************************************/
   /*!
       @brief Current head in use, based on internal caching
       @return Head 0 or 1
   */
   /**************************************************************************/
-  virtual int8_t get_side() = 0;
+  virtual int get_side() = 0;
   /**************************************************************************/
   /*!
       @brief  The current track location, based on internal caching
@@ -113,7 +113,7 @@ public:
       @note Returns -1 if the track is not known.
   */
   /**************************************************************************/
-  virtual int8_t track(void) = 0;
+  virtual int track(void) = 0;
   /**************************************************************************/
   /*!
       @brief  Check whether the floppy in the drive is write protected
@@ -239,10 +239,10 @@ public:
 
   void select(bool selected) override;
   bool spin_motor(bool motor_on) override;
-  bool goto_track(uint8_t track) override;
-  bool side(uint8_t head) override;
-  int8_t track(void) override;
-  int8_t get_side(void) override;
+  bool goto_track(int track) override;
+  bool side(int head) override;
+  int track(void) override;
+  int get_side(void) override;
   void step(bool dir, uint8_t times);
   bool set_density(bool high_density) override;
   bool get_write_protect() override;
@@ -254,7 +254,7 @@ private:
   int8_t _densitypin, _selectpin, _motorpin, _directionpin, _steppin,
       _track0pin, _protectpin, _sidepin, _readypin;
 
-  int8_t _track = -1, _side = -1;
+  int _track = -1, _side = -1;
 };
 
 /**************************************************************************/
@@ -284,19 +284,19 @@ public:
 
   void select(bool selected) override;
   bool spin_motor(bool motor_on) override;
-  bool goto_track(uint8_t track) override;
-  bool side(uint8_t head) override;
-  int8_t track(void) override;
+  bool goto_track(int track) override;
+  bool side(int head) override;
+  int track(void) override;
   bool set_density(bool high_density) override;
   bool get_write_protect() override;
   bool get_track0_sense() override;
   bool get_ready_sense() override { return true; }
 
-  int8_t quartertrack();
+  int quartertrack();
   bool goto_quartertrack(int);
   void step_mode(StepMode mode);
 
-  int8_t get_side() override { return 0; }
+  int get_side() override { return 0; }
 
 private:
   int _step_multiplier() const;
@@ -324,7 +324,7 @@ public:
   void end(void);
 
   uint32_t size(void) const;
-  int32_t readTrack(uint8_t track, bool head);
+  int32_t readTrack(int track, bool head);
 
   /**! @brief The expected number of sectors per track in this format
        @returns The number of sectors per track */

--- a/src/Adafruit_MFM_Floppy.cpp
+++ b/src/Adafruit_MFM_Floppy.cpp
@@ -113,7 +113,7 @@ uint32_t Adafruit_MFM_Floppy::size(void) const {
     @returns Number of sectors captured, or -1 if we couldn't seek
 */
 /**************************************************************************/
-int32_t Adafruit_MFM_Floppy::readTrack(uint8_t logical_track, bool head) {
+int32_t Adafruit_MFM_Floppy::readTrack(int logical_track, bool head) {
   syncDevice();
 
   uint8_t physical_track = _double_step ? 2 * logical_track : logical_track;


### PR DESCRIPTION
GW and fluxengine host software will need changes to get Apple Disk ][ fluxing working again, but with a 1-liner change, GW v1.21 can talk to floppsy and see flux on a Disk ][....

```patch
diff --git a/src/greaseweazle/tools/util.py b/src/greaseweazle/tools/util.py
index 25cb4e7..33c2316 100644
--- a/src/greaseweazle/tools/util.py
+++ b/src/greaseweazle/tools/util.py
@@ -125,6 +125,7 @@ class Drive:
             '0': (USB.BusType.Shugart, 0),
             '1': (USB.BusType.Shugart, 1),
             '2': (USB.BusType.Shugart, 2),
+            'APPLE2': (USB.BusType.Apple2, 0),
         }
         if not letter.upper() in types:
             raise argparse.ArgumentTypeError("invalid drive letter: '%s'"
```

You have to use `--tracks step=4` because our GW-compatible firmware steps 1/4 track each time a step is commanded.

I had a random floppy left over in the drive and it reads consistently but with errors:
```
$ gw read --drive APPLE2 --format apple2.nofs.140 /tmp/apple2.img  --device /dev/serial/by-id/usb-Adafruit_Floppsy_E4634012C72D5B24-if00  --tracks step=4
…
Cyl-> 0         1         2         3    
H. S: 01234567890123456789012345678901234
0. 0: .X....X..X.XX.XX.XX.XX.XX.X..X.XX.X
0. 1: .X..X..X.X..X.XX.XX.XX.XX.XX.XX.X..
0. 2: .XX.XX.X..X....X..X.XX.XX.XX.XX.XX.
0. 3: .XX.XX.XX.XX.X....XX.X..X.XX.XX.XX.
0. 4: ..X.XX.XX.XX.XX.XX.X....X..X.XX.XX.
0. 5: .....X.XX.XX.XX.XX.X..XX.X..X.XX.XX
0. 6: X..X....X..X.XX.XX.XX.XX.XX.X..X..X
0. 7: .X.X..X..X....X..X.XX.XX.XX.XX.XX.X
0. 8: XX.XX.X..X..X..X.X..X.XX.XX.XX.XX.X
0. 9: XX.XX.XX.XX.XX.X..X..X.XX.X.XX.XX.X
0.10: .X..X.XX.XX.XX.XX.XX.X..X..X.XX.X.X
0.11: ..X....X..X.XX.XX.XX.XX.XX.X..X.XX.
0.12: X.X..X..X.X..X..X.XX.XX.XX.XX.XX.X.
0.13: X.XX.XX.X..X..X.X..X.XX.XX.XX.XX.XX
0.14: X.XX.XX..X.XX.X..X....X..X.XX.XX.XX
0.15: X..X.XX.XX.XX.XX.XX.X..X.XX.X.XX.XX
Found 264 sectors of 560 (47%)
```