### PR TITLE
Support gw --fake-index=

### DIFF
--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -167,7 +167,7 @@ public:
       __attribute__((optimize("O3")));
 
   bool write_track(uint8_t *pulses, size_t n_pulses,
-                   bool store_greaseweazle = false)
+                   bool store_greaseweazle = false, bool use_index = true)
       __attribute__((optimize("O3")));
   void print_pulse_bins(uint8_t *pulses, size_t n_pulses, uint8_t max_bins = 64,
                         bool is_gw_format = false, uint32_t min_bin_size = 100);

--- a/src/arch_rp2.h
+++ b/src/arch_rp2.h
@@ -18,7 +18,8 @@ rp2040_flux_capture(int indexpin, int rdpin, volatile uint8_t *pulses,
                     uint32_t index_wait_ms);
 extern bool rp2040_flux_write(int index_pin, int wrgate_pin, int wrdata_pin,
                               uint8_t *pulses, uint8_t *pulse_end,
-                              bool store_greaseweazel, bool is_apple2);
+                              bool store_greaseweazel, bool is_apple2,
+                              bool use_index);
 #endif
 
 #if defined(__cplusplus)


### PR DESCRIPTION
This allows reading (and potentially writing, though I did not test this!) floppies when there's no index input available. The user must supply the correct revolution time, e.g., --fake-index=200ms.

Tested using a ribbon cable with the grey "pin 8" wire removed & a DOS 1.4MB floppy. Also tested regular mode with an unmodified cable.