### PR TITLE
build mfm emulator during CI

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Adafruit's floppy disk drive interfacing library
 category=Communication
 url=https://github.com/adafruit/Adafruit_Floppy
 architectures=*
-depends=Adafruit BusIO, SdFat - Adafruit Fork, Adafruit ST7735 and ST7789 Library
+depends=Adafruit BusIO, SdFat - Adafruit Fork, Adafruit ST7735 and ST7789 Library,Adafruit NeoPixel


### PR DESCRIPTION
#46 reports that the mfm emulator doesn't successfully build. I intended to test that it builds during CI, but apparently failed to do so.