### PR TITLE
bump version number in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Floppy
-version=0.3.0
+version=0.6.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Adafruit's floppy disk drive interfacing library


### PR DESCRIPTION
In #48 it's reported that the library identifies as 0.3.0 erroneously. This is because I forget that arduino requires manually updating the version string in a file with each release (boo).

@caternuson can you hold my hand and help me get a valid release made? thanks in anticipation!