### PR TITLE
SA400 needs slower 12000us step. If track 0 seeks fails, set _track = -1

### DIFF
--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -354,7 +354,7 @@ bool Adafruit_Floppy::goto_track(int track_num) {
 
       if (digitalRead(_track0pin)) {
         // STILL not found!
-	_track = -1; // We don't know where we really are
+        _track = -1; // We don't know where we really are
         if (debug_serial)
           debug_serial->println("Could not find track 0");
         return false; // we 'timed' out, were not able to locate track 0

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -139,7 +139,7 @@ void Adafruit_FloppyBase::soft_reset(void) {
   }
 
   select_delay_us = 10;
-  step_delay_us = 10000;
+  step_delay_us = 12000;
   settle_delay_ms = 15;
   motor_delay_ms = 1000;
   watchdog_delay_ms = 1000;
@@ -354,6 +354,7 @@ bool Adafruit_Floppy::goto_track(int track_num) {
 
       if (digitalRead(_track0pin)) {
         // STILL not found!
+	_track = -1; // We don't know where we really are
         if (debug_serial)
           debug_serial->println("Could not find track 0");
         return false; // we 'timed' out, were not able to locate track 0


### PR DESCRIPTION
This is a simple change that increases the seek time from 10000us to 12000us and also sets _track to -1 if the track 0 seek fails as we don't really know where we are at that point.

This doesn't completely address all the issues with the SA400 drive as it appears to require the motor to be on to do any seeks or even to read the track 0 signal.

