### PR TITLE
Cache drive select and motor on moving it out of Greaseweazle

### DIFF
--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -216,7 +216,8 @@ void loop() {
   if (!cmd_len) {
     if ((millis() > timestamp) && ((millis() - timestamp) > 10000)) {
       Serial1.println("Timed out waiting for command, resetting motor");
-      if (floppy && floppy->drive_is_selected()) {
+      if (floppy && floppy->motor_is_spinning()) {
+        floppy->select(true); // Need to select before we can move
         Serial1.println("goto track 0");
         floppy->goto_track(0);
         Serial1.println("stop motor");

--- a/examples/greaseweazle/greaseweazle.ino
+++ b/examples/greaseweazle/greaseweazle.ino
@@ -222,6 +222,8 @@ void loop() {
         floppy->goto_track(0);
         Serial1.println("stop motor");
         floppy->spin_motor(false);
+      }
+      if (floppy && floppy->drive_is_selected()) {
         Serial1.println("deselect");
         floppy->select(false);
       }

--- a/src/Adafruit_Floppy.cpp
+++ b/src/Adafruit_Floppy.cpp
@@ -291,7 +291,7 @@ bool Adafruit_Floppy::side(int head) {
 /**************************************************************************/
 bool Adafruit_Floppy::spin_motor(bool motor_on) {
   if (motor_on == is_motor_spinning)
-    return true;  // Already in the correct state
+    return true; // Already in the correct state
 
   digitalWrite(_motorpin, !motor_on); // Motor on is logic level 0!
   is_motor_spinning = motor_on;
@@ -1050,7 +1050,9 @@ void Adafruit_Apple2Floppy::select(bool selected) {
 */
 /**************************************************************************/
 bool Adafruit_Apple2Floppy::spin_motor(bool motor_on) {
-  if (motor_on == is_motor_spinning) return true;  // already in correct state
+  if (motor_on == is_motor_spinning)
+    return true; // already in correct state
+
   if (motor_on) {
     delay(motor_delay_ms); // Main motor turn on
 

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -75,6 +75,14 @@ public:
   virtual void select(bool selected) = 0;
   /**************************************************************************/
   /*!
+      @brief  Is the drive selected based on interal caching
+      @returns True if the drive is selected, false otherwise
+  */
+  /**************************************************************************/
+  bool drive_is_selected(void) { return is_drive_selected; }
+
+  /**************************************************************************/
+  /*!
       @brief  Turn on or off the floppy motor, if on we wait till we get an
      index pulse!
       @param motor_on True to turn on motor, False to turn it off
@@ -83,6 +91,13 @@ public:
   */
   /**************************************************************************/
   virtual bool spin_motor(bool motor_on) = 0;
+  /**************************************************************************/
+  /*!
+      @brief  Is the drive motor spinning based on interal caching
+      @returns True if the motor is spinning, false otherwise
+  */
+  /**************************************************************************/
+  bool motor_is_spinning(void) { return is_motor_spinning; }
   /**************************************************************************/
   /*!
       @brief  Seek to the desired track, requires the motor to be spun up!
@@ -193,6 +208,7 @@ public:
 
 protected:
   bool read_index();
+  bool is_drive_selected, is_motor_spinning;
 
 private:
 #if defined(__SAMD51__)

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -208,7 +208,8 @@ public:
 
 protected:
   bool read_index();
-  bool is_drive_selected, is_motor_spinning;
+  bool is_drive_selected; ///< cached drive select state
+  bool is_motor_spinning; ///< cached motor spinning state
 
 private:
 #if defined(__SAMD51__)

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -100,6 +100,13 @@ public:
   bool motor_is_spinning(void) { return is_motor_spinning; }
   /**************************************************************************/
   /*!
+      @brief  Are index pulses being seen?
+      @returns True if we're seeing index pulses, false otherwise
+  */
+  /**************************************************************************/
+  bool index_pulses_seen(void) { return is_index_seen; }
+  /**************************************************************************/
+  /*!
       @brief  Seek to the desired track, requires the motor to be spun up!
       @param  track_num The track to step to
       @return True If we were able to get to the track location
@@ -210,6 +217,7 @@ protected:
   bool read_index();
   bool is_drive_selected; ///< cached drive select state
   bool is_motor_spinning; ///< cached motor spinning state
+  bool is_index_seen; ///< cached index pulses seen state
 
 private:
 #if defined(__SAMD51__)

--- a/src/Adafruit_Floppy.h
+++ b/src/Adafruit_Floppy.h
@@ -217,7 +217,7 @@ protected:
   bool read_index();
   bool is_drive_selected; ///< cached drive select state
   bool is_motor_spinning; ///< cached motor spinning state
-  bool is_index_seen; ///< cached index pulses seen state
+  bool is_index_seen;     ///< cached index pulses seen state
 
 private:
 #if defined(__SAMD51__)


### PR DESCRIPTION
This change adds caching of the drive select and motor states in Adafruit_FloppyBase since it and its child classes manage these signals.

Update Greaseweazle code to use these new cached versions instead of its own version and only try to stop the motor in a loop() timeout if the drive is currently selected. The existing code may try to move head to track 0 and turn off the motor after a previous greaseweazle command or the last timeout deselected the drive resulting in the operation failing as attempting to seek track 0 will fail unless the drive is first selected. On SA400 drives, the head needs to load before seeks can be done and the track 0 signal becomes active and that makes a clacking sound each time which is unnecessary every few seconds.

