### PR TITLE
correct calculation in greaseunpack for 2 byte value

### DIFF
--- a/src/greasepack.h
+++ b/src/greasepack.h
@@ -83,7 +83,7 @@ static inline unsigned greaseunpack(uint8_t **buf_, uint8_t *end,
     }
     if (need == 2) {
       uint8_t data2 = *BUF++;
-      return (data - cutoff_1byte + 1) * 250 + data2;
+      return 250 + (data - cutoff_1byte) * 255 + data2 - 1;
     }
     uint8_t data2 = *BUF++;
     if (data2 != 2) {


### PR DESCRIPTION
File greasepack.h
The calculation in greaseunpack for a 2 byte code (values between 250..1524) was wrong

**Example**
encoding the value 1000 in greaspack()
unsigned high = (value - 250) / 255; -> (1000 - 250) / 255 => 2
*buf++ = 250 + high; -> 250 + 2 => **252**
*buf++ = 1 + (value - 250) % 255; -> 1 + (1000 - 250) % 255 => **241**

decoding 252, 241
old: (252 - 250 + 1) * 250 + 241 => **991 wrong**
new: 250 + (252 -250) * 255 + 241 -1 => **1000 correct**
